### PR TITLE
Add initial API version template

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,4 +23,4 @@ version: 1.0.4
 # It is recommended to use it with quotes.
 appVersion: "0.0.0"
 
-dependencies:
+dependencies: []

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -1,6 +1,6 @@
 # harness-common
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Helm Common library for Harness Helm Charts
 

--- a/src/common/templates/_apiVersions.tpl
+++ b/src/common/templates/_apiVersions.tpl
@@ -1,0 +1,26 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Templates determining which Kubernetes API versions to use for required API
+kinds.
+*/}}
+
+{{/*
+Define which `policy` apiVersion to use. Relevant kinds include:
+- PodDisruptionBudget
+
+Usage:
+{{ include "harnesscommon.apiVersions.policy" $ }}
+
+Params:
+  - root context
+*/}}
+{{- define "harnesscommon.apiVersions.policy" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+policy/v1
+{{- else if .Capabilities.APIVersions.Has "policy/v1beta1" -}}
+policy/v1beta1
+{{- else -}}
+{{- fail "no compatible 'policy' API version was found; ensure available Kubernetes APIs satisfy Harness compatibility requirements" -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Establish a pattern for managing API versions (`apiVersion`) for required Kinds (`kind`) throughout chart manifests.