### PR TITLE
SMP-1338: add functions for external redis env and connection string

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnections.tpl
+++ b/src/common/templates/_databaseconnections.tpl
@@ -25,6 +25,8 @@
 {{- $installed := (pluck $type .context.Values.global.database | first ).installed }}
 {{- $protocol := (pluck $type .context.Values.global.database | first ).protocol }}
 {{- $extraArgs:= (pluck $type .context.Values.global.database | first ).extraArgs }}
+{{- $userVariableName := default (printf "%s_USER" $type) .userVariableName -}}
+{{- $passwordVariableName := default (printf "%s_PASSWORD" $type) .passwordVariableName -}}
 {{- if $installed }}
   {{- $namespace := .context.Release.Namespace }}
   {{- if .context.Values.global.ha -}}
@@ -34,7 +36,7 @@
   {{- end }}
 {{- else }}
 {{- $args := (printf "/%s?%s" .database $extraArgs )}}
-{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" $args )}}
+{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" $args "userVariableName" $userVariableName "passwordVariableName" $passwordVariableName)}}
 {{- end }}
 {{- end }}
 
@@ -67,11 +69,13 @@
 {{- $hosts := (pluck $type .context.Values.global.database | first ).hosts }}
 {{- $protocol := (pluck $type .context.Values.global.database | first ).protocol }}
 {{- $installed := (pluck $type .context.Values.global.database | first).installed }}
+{{- $userVariableName := default (printf "%s_USER" $type) .userVariableName -}}
+{{- $passwordVariableName := default (printf "%s_PASSWORD" $type) .passwordVariableName -}}
 {{- if $installed }}
 {{- $connectionString := (printf "%s://$(%s_USER):$(%s_PASSWORD)@%s" "postgres" $dbType $dbType "postgres:5432") }}
 {{- printf "%s" $connectionString }}
 {{- else }}
-{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol )}}
+{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "userVariableName" $userVariableName "passwordVariableName" $passwordVariableName)}}
 {{- end }}
 {{- end }}
 
@@ -99,8 +103,10 @@
 {{- define "harnesscommon.dbconnection.timescaleConnection" }}
 {{- $type := "timescaledb" }}
 {{- $hosts := (pluck $type .context.Values.global.database | first ).hosts }}
+{{- $userVariableName := default (printf "%s_USER" $type) .userVariableName -}}
+{{- $passwordVariableName := default (printf "%s_PASSWORD" $type) .passwordVariableName -}}
 {{- $protocol := (pluck $type .context.Values.global.database | first ).protocol }}
-{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" "/harness") }}
+{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" "/harness" "userVariableName" $userVariableName "passwordVariableName" $passwordVariableName) }}
 {{- end}}
 
 {{/* Generates Redis environment variables
@@ -123,19 +129,10 @@
 */}}
 {{- define "harnesscommon.dbconnection.redisConnection" -}}
 {{- $type := "redis" -}}
-{{- $hosts := list -}}
-{{- $protocol := "redis" -}}
-{{- if .context.installed  -}}
-{{- printf "redis://redis-sentinel-harness-announce-0:26379,redis://redis-sentinel-harness-announce-1:26379,redis://redis-sentinel-harness-announce-2:26379" -}}
-{{- else -}}
-{{- $hosts = .context.hosts -}}
-{{- $protocol = .context.protocol -}}
-{{- $firsthost := (index $hosts 0) -}}
-{{- $extraArgs := .context.extraArgs -}}
-{{- $connectionString := (printf "%s://%s" $protocol $firsthost) -}}
-{{- if $extraArgs -}}
-  {{- $connectionString = (printf "%s%s" $connectionString $extraArgs ) -}}
+{{- $hosts := .context.hosts -}}
+{{- $protocol := .context.protocol -}}
+{{- if and (.context.installed) (empty $hosts) -}}
+  {{- $hosts = list "redis-sentinel-harness-announce-0:26379" "redis-sentinel-harness-announce-1:26379" "redis-sentinel-harness-announce-2:26379" }}
 {{- end -}}
-{{- printf "%s" $connectionString -}}
-{{- end -}}
+{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" .context.extraArgs "userVariableName" .userVariableName "passwordVariableName" .passwordVariableName "connectionType" "list") }}
 {{- end -}}

--- a/src/common/templates/_databasehelpers.tpl
+++ b/src/common/templates/_databasehelpers.tpl
@@ -1,4 +1,8 @@
 
+{{/* Generates db user environment reference. If variableName is not provided, default one is generated using db type.
+Secret and userValue are mutually exclusive
+{{ include "harnesscommon.dbconnection.dbenvuser" (dict "type" "redis" "variableName" "REDIS_USER" "userValue" "test-user" "secret" "redis-secret" "userKey" "redis-user-key" )}}
+*/}}
 {{- define "harnesscommon.dbconnection.dbenvuser" }}
 {{- $dbType := upper .type }}
 {{- $name := default (printf "%s_USER" $dbType) .variableName }}
@@ -13,6 +17,9 @@
 {{- end }}
 {{- end }}
 
+{{/* Generates db password environment reference. If variableName is not provided, default one is generated using db type.
+{{ include "harnesscommon.dbconnection.dbenvpassword" (dict "type" "redis" "variableName" "REDIS_PASSWORD" "secret" "redis-secret" "passwordKey" "redis-password-key" )}}
+*/}}
 {{- define "harnesscommon.dbconnection.dbenvpassword" }}
 {{- $dbType := upper .type }}
 {{- $name := default (printf "%s_PASSWORD" $dbType) .variableName }}
@@ -23,6 +30,10 @@
       key: {{ printf "%s" .passwordKey }}
 {{- end }}
 
+{{/* Generates db connection string. If userVariableName or passwordVariableName is not provided, no credentials are added to connection string.
+If connectionType is set other than "string" then protocol and credentials are added to every host
+{{ include "harnesscommon.dbconnection.connection" (dict "type" "redis" "userVariableName" "REDIS_USER" "passwordVariableName" "REDIS_PASSWORD" "hosts" (list "redis-1:6379" "redis-2:6379") "protocol" "redis" "connectionType" "string" )}}
+*/}}
 {{- define "harnesscommon.dbconnection.connection" -}}
 {{- $dbType := upper .type -}}
 {{- $firsthost := (index .hosts 0) -}}

--- a/src/common/templates/_databasehelpers.tpl
+++ b/src/common/templates/_databasehelpers.tpl
@@ -1,7 +1,8 @@
 
 {{- define "harnesscommon.dbconnection.dbenvuser" }}
 {{- $dbType := upper .type }}
-- name: {{ printf "%s_USER" $dbType }}
+{{- $name := default (printf "%s_USER" $dbType) .variableName }}
+- name: {{ $name }}
 {{- if .userValue }}
   value: {{ printf "%s" .userValue }}
 {{- else }}
@@ -14,24 +15,27 @@
 
 {{- define "harnesscommon.dbconnection.dbenvpassword" }}
 {{- $dbType := upper .type }}
-- name: {{ printf "%s_PASSWORD" $dbType }}
+{{- $name := default (printf "%s_PASSWORD" $dbType) .variableName }}
+- name: {{ $name }}
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s" .secret }}
       key: {{ printf "%s" .passwordKey }}
 {{- end }}
 
-{{- define "harnesscommon.dbconnection.connection" }}
-{{- $dbType := upper .type }}
-{{- $firsthost := (index .hosts 0) }}
-{{- $protocol := .protocol }}
-{{- $extraArgs := .extraArgs }}
-{{- $connectionString := (printf "%s://$(%s_USER):$(%s_PASSWORD)@%s" $protocol $dbType $dbType $firsthost) }}
-{{- range $host := (rest .hosts) }}
-{{- $connectionString = printf "%s,%s" $connectionString $host }}
-{{- end}}
-{{- if $extraArgs }}
-{{- $connectionString = (printf "%s%s" $connectionString $extraArgs ) }}
-{{- end }}
-{{- printf "%s" $connectionString }}
-{{- end }}
+{{- define "harnesscommon.dbconnection.connection" -}}
+{{- $dbType := upper .type -}}
+{{- $firsthost := (index .hosts 0) -}}
+{{- $protocol := .protocol -}}
+{{- $extraArgs := .extraArgs -}}
+{{- $userVariableName := default (printf "%s_USER" $dbType) .userVariableName -}}
+{{- $passwordVariableName := default (printf "%s_PASSWORD" $dbType) .passwordVariableName -}}
+{{- $connectionString := (printf "%s://$(%s):$(%s)@%s" $protocol $userVariableName $passwordVariableName $firsthost) -}}
+{{- range $host := (rest .hosts) -}}
+  {{- $connectionString = printf "%s,%s" $connectionString $host -}}
+{{- end -}}
+{{- if $extraArgs -}}
+  {{- $connectionString = (printf "%s%s" $connectionString $extraArgs ) -}}
+{{- end -}}
+{{- printf "%s" $connectionString -}}
+{{- end -}}


### PR DESCRIPTION
1. Added arguments to specify custom env variable names for username and password because different services expect different names.
2. Added custom code for redis connection string and env variables