### PR TITLE
external Postgres changes to add default database and additional parameters

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.18
+version: 1.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnections.tpl
+++ b/src/common/templates/_databaseconnections.tpl
@@ -62,7 +62,7 @@
 {{- end }}
 
 {{/* Generates Postgres Connection string
-{{ include "harnesscommon.dbconnection.postgresConnection" (dict "context" $) }}
+{{ include "harnesscommon.dbconnection.postgresConnection" (dict "database" "foo" "args" "bar" "context" $) }}
 */}}
 {{- define "harnesscommon.dbconnection.postgresConnection" }}
 {{- $type := "postgres" }}
@@ -70,13 +70,15 @@
 {{- $hosts := (pluck $type .context.Values.global.database | first ).hosts }}
 {{- $protocol := (pluck $type .context.Values.global.database | first ).protocol }}
 {{- $installed := (pluck $type .context.Values.global.database | first).installed }}
+{{- $extraArgs:= (pluck $type .context.Values.global.database | first ).extraArgs }}
 {{- $userVariableName := default (printf "%s_USER" $dbType) .userVariableName -}}
 {{- $passwordVariableName := default (printf "%s_PASSWORD" $dbType) .passwordVariableName -}}
 {{- if $installed }}
-{{- $connectionString := (printf "%s://$(%s_USER):$(%s_PASSWORD)@%s" "postgres" $dbType $dbType "postgres:5432") }}
+{{- $connectionString := (printf "%s://$(%s_USER):$(%s_PASSWORD)@%s/%s?%s" "postgres" $dbType $dbType "postgres:5432" .database .args) }}
 {{- printf "%s" $connectionString }}
 {{- else }}
-{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "userVariableName" $userVariableName "passwordVariableName" $passwordVariableName)}}
+{{- $appendedArgs := (printf "/%s?%s&%s" .database .args $extraArgs )}}
+{{- include "harnesscommon.dbconnection.connection" (dict "type" $type "hosts" $hosts "protocol" $protocol "extraArgs" $appendedArgs "userVariableName" $userVariableName "passwordVariableName" $passwordVariableName)}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Added database and argument support.
Usage:
If you have local arguments used specifically for a particular microservice it will get appended with global arguments with '&' seperation.
{{ include "harnesscommon.dbconnection.postgresConnection" (dict "database" "harness-sto" "args" "search_path=sto" "context" $) }}

if you have global arguments like:
connect_timeout=10&sslmode=require
it is going to render like this:
- name: APP_DB_MIGRATION_DATASOURCE
   value: postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/harness-sto?search_path=sto&connect_timeout=10&sslmode=require 
