### PR TITLE
SMP-1702: add support to use external redis without password

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnections.tpl
+++ b/src/common/templates/_databaseconnections.tpl
@@ -126,7 +126,7 @@
 {{- end }}
 {{- if .enableSslVariableName }}
 - name: {{ printf "%s" .enableSslVariableName }}
-  value: {{ (printf "%s\n" "'true'") }} 
+  value: {{ (printf "%s\n" "'true'") }}
 {{- end }}
 {{- if .certVariableName }}
 - name: {{ .certVariableName  }}
@@ -197,9 +197,23 @@
 {{- $passwordKey := .context.passwordKey }}
 {{- $userKey := .context.userKey }}
 {{- $installed := .context.installed }}
-{{- if not $installed }}
+{{- if and (not $installed) $passwordSecret }}
 {{- include "harnesscommon.dbconnection.dbenvuser" (dict "type" $type "secret" $passwordSecret  "userKey" $userKey "variableName" .userVariableName ) }}
 {{- include "harnesscommon.dbconnection.dbenvpassword" (dict "type" $type "secret" $passwordSecret "passwordKey" $passwordKey "variableName" .passwordVariableName ) }}
+{{- end }}
+{{- end }}
+
+{{/* Outputs whether redis password is set or not
+{{ include "harnesscommon.dbconnection.isRedisPasswordSet" (dict "context" .Values.global.database.redis) }}
+*/}}
+{{- define "harnesscommon.dbconnection.isRedisPasswordSet" }}
+{{- $passwordSecret := .context.secretName }}
+{{- $passwordKey := .context.passwordKey }}
+{{- $installed := .context.installed }}
+{{- if and (not $installed) $passwordSecret $passwordKey }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
 {{- end }}
 {{- end }}
 

--- a/src/common/templates/_databasehelpers.tpl
+++ b/src/common/templates/_databasehelpers.tpl
@@ -6,10 +6,11 @@ Secret and userValue are mutually exclusive
 {{- define "harnesscommon.dbconnection.dbenvuser" }}
 {{- $dbType := upper .type }}
 {{- $name := default (printf "%s_USER" $dbType) .variableName }}
-- name: {{ $name }}
 {{- if .userValue }}
+- name: {{ $name }}
   value: {{ printf "%s" .userValue }}
-{{- else }}
+{{- else if .userKey }}
+- name: {{ $name }}
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s" .secret }}
@@ -23,11 +24,13 @@ Secret and userValue are mutually exclusive
 {{- define "harnesscommon.dbconnection.dbenvpassword" }}
 {{- $dbType := upper .type }}
 {{- $name := default (printf "%s_PASSWORD" $dbType) .variableName }}
+{{- if .passwordKey }}
 - name: {{ $name }}
   valueFrom:
     secretKeyRef:
       name: {{ printf "%s" .secret }}
       key: {{ printf "%s" .passwordKey }}
+{{- end }}
 {{- end }}
 
 {{/* Generates db connection string. If userVariableName or passwordVariableName is not provided, no credentials are added to connection string.

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -34,3 +34,8 @@ global:
       userKey: ""
       passwordKey: ""
       extraArgs: ""
+    redis:
+      installed: false
+      secretName: "secret"
+      userKey: "user"
+      passwordKey: "password"

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -35,7 +35,11 @@ global:
       passwordKey: ""
       extraArgs: ""
     redis:
-      installed: false
+      installed: true
+      protocol: "redis"
+      hosts:
+      - "redis:6379"
       secretName: "secret"
       userKey: "user"
       passwordKey: "password"
+      extraArgs: ""


### PR DESCRIPTION
- We have added external redis authentication support in 800xx but we have 798xx as the release candidate for July.
- We have not gotten required approvals on Hotfix PR for 798xx authentication support yet
- Hence, we will release SMP 0.8.0 without authentication support.
- For that, charts need to support empty secrets.