### PR TITLE
SMP-2100: Add tmpl function for smtp secrets

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnectionsv2.tpl
+++ b/src/common/templates/_databaseconnectionsv2.tpl
@@ -89,9 +89,13 @@ USAGE:
     {{- $host := include "harnesscommon.dbconnectionv2.timescaleHost" (dict "context" .context ) }}
     {{- $port := include "harnesscommon.dbconnectionv2.timescalePort" (dict "context" .context ) }}
     {{- $connectionString := "" }}
-    {{- $protocol := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" $ "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
+    {{- $protocol := "" }}
     {{- if not (empty .protocol) }}
         {{- $protocol = (printf "%s://" .protocol) }}
+    {{- end }}
+    {{- $protocolVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" $ "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
+    {{- if not (empty $protocolVar) }}
+        {{- $protocol = (printf "%s://" $protocolVar) }}
     {{- end }}
     {{- $userAndPassField := "" }}
     {{- if and (.userVariableName) (.passwordVariableName) }}

--- a/src/common/templates/_smtp-secrets-helper.tpl
+++ b/src/common/templates/_smtp-secrets-helper.tpl
@@ -1,0 +1,17 @@
+{{/*
+Generates SMTP environment variables
+
+USAGE:
+{{ include "harnesscommon.secrets.manageSMTPEnv" (dict "ctx" $) | indent 12 }}
+*/}}
+{{- define "harnesscommon.secrets.manageSMTPEnv" }}
+    {{- $ := .ctx }}
+    {{- if $.Values.global.smtpCreateSecret.enabled }}
+        {{- $globalSMTPESOSecretIdentifier := include "harnesscommon.secrets.globalESOSecretCtxIdentifier" (dict "ctx" $  "ctxIdentifier" "smtp") }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "SMTP_USERNAME" "defaultKubernetesSecretName" "smtp-secret" "defaultKubernetesSecretKey" "SMTP_USERNAME" "extKubernetesSecretCtxs" (list $.Values.global.smtpCreateSecret.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalSMTPESOSecretIdentifier "secretCtx" $.Values.global.smtpCreateSecret.secrets.secretManagement.externalSecretsOperator))) }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "SMTP_PASSWORD" "defaultKubernetesSecretName" "smtp-secret" "defaultKubernetesSecretKey" "SMTP_PASSWORD" "extKubernetesSecretCtxs" (list $.Values.global.smtpCreateSecret.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalSMTPESOSecretIdentifier "secretCtx" $.Values.global.smtpCreateSecret.secrets.secretManagement.externalSecretsOperator))) }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "SMTP_HOST" "defaultKubernetesSecretName" "smtp-secret" "defaultKubernetesSecretKey" "SMTP_HOST" "extKubernetesSecretCtxs" (list $.Values.global.smtpCreateSecret.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalSMTPESOSecretIdentifier "secretCtx" $.Values.global.smtpCreateSecret.secrets.secretManagement.externalSecretsOperator))) }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "SMTP_PORT" "defaultKubernetesSecretName" "smtp-secret" "defaultKubernetesSecretKey" "SMTP_PORT" "extKubernetesSecretCtxs" (list $.Values.global.smtpCreateSecret.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalSMTPESOSecretIdentifier "secretCtx" $.Values.global.smtpCreateSecret.secrets.secretManagement.externalSecretsOperator))) }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "SMTP_USE_SSL" "defaultKubernetesSecretName" "smtp-secret" "defaultKubernetesSecretKey" "SMTP_USE_SSL" "extKubernetesSecretCtxs" (list $.Values.global.smtpCreateSecret.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalSMTPESOSecretIdentifier "secretCtx" $.Values.global.smtpCreateSecret.secrets.secretManagement.externalSecretsOperator))) }}
+    {{- end }}
+{{- end }}

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -43,3 +43,40 @@ global:
       userKey: "user"
       passwordKey: "password"
       extraArgs: ""
+  smtpCreateSecret:
+    enabled: false
+    SMTP_USERNAME: ""
+    SMTP_PASSWORD: ""
+    SMTP_HOST: ""
+    SMTP_USE_SSL: "true"
+    SMTP_PORT: "465"
+    secrets:
+      kubernetesSecrets:
+        - secretName: ""
+          keys:
+            SMTP_USERNAME: ""
+            SMTP_PASSWORD": ""
+            SMTP_HOST: ""
+            SMTP_PORT": ""
+            SMTP_USE_SSL": ""
+      secretManagement: 
+        externalSecretsOperator:
+          - secretStore:
+              name: ""
+              kind: ""
+            remoteKeys:
+              SMTP_USERNAME:
+                name: ""
+                property: ""
+              SMTP_PASSWORD":
+                name: ""
+                property: ""
+              SMTP_HOST:
+                name: ""
+                property: ""
+              SMTP_PORT":
+                name: ""
+                property: ""
+              SMTP_USE_SSL:
+                name: ""
+                property: ""


### PR DESCRIPTION
1. Added tmpl func to support external secrets for SMTP
2. Fixed precedence order of "protocol" field of timescaledb 

Testing:
![image](https://github.com/harness/helm-common/assets/134731283/a1d00973-bee9-4742-afe5-902eefc9c7b8)
