### PR TITLE
SMP-2100: Update tmpl functions for External Secrets

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnectionsv2.tpl
+++ b/src/common/templates/_databaseconnectionsv2.tpl
@@ -189,7 +189,7 @@ USAGE:
 {{- end }}
 
 {{/*
-Generates Redis environment variables
+Outputs whether redis password is set or not
 
 USAGE:
 {{ include "harnesscommon.dbconnectionv2.isRedisPasswordSet" (dict "context" $ "passwordVariableName" "REDIS_PASSWORD" "localRedisCtx" .Values.redis "globalRedisCtx" .Values.global.database.redis) | indent 12 }}

--- a/src/common/templates/_eso-secrets-helper.tpl
+++ b/src/common/templates/_eso-secrets-helper.tpl
@@ -21,6 +21,24 @@ Example:
 {{- end }}
 
 {{/*
+Check if only one valid ESO Secret is provided in the secrets context
+
+Returns: bool
+
+Example:
+{{ include "harnesscommon.secrets.hasSingleValidESOSecret" (dict "secretsCtx" .Values.secrets) }}
+*/}}
+{{- define "harnesscommon.secrets.hasSingleValidESOSecret" }}
+  {{- $secretsCtx := .secretsCtx }}
+  {{- $hasSingleValidESOSecret := "false" }}
+  {{- if and $secretsCtx .secretsCtx.secretManagement $secretsCtx.secretManagement.externalSecretsOperator (eq (len $secretsCtx.secretManagement.externalSecretsOperator) 1) }}
+    {{- $externalSecret := first $secretsCtx.secretManagement.externalSecretsOperator }}
+        {{- $hasSingleValidESOSecret = include "harnesscommon.secrets.hasValidESOSecret" (dict "esoSecretCtx" $externalSecret) }}
+  {{- end }}
+  {{- print $hasSingleValidESOSecret }}
+{{- end }}
+
+{{/*
 Generate ESO Local Secret Context Identifier
 
 Generates Identifier following the format: <chart-name>-<additional-ctx-identifier>-ext-secret


### PR DESCRIPTION
1. Add `harnesscommon.dbconnectionv2.isRedisPasswordSet`
2. Update `harnesscommon.dbconnectionv2.mongoEnv ` to support `userVariableName`, `passwordVariableName` as inputs
3. Update `harnesscommon.dbconnectionv2.mongoConnection` to support `userVariableName`, `passwordVariableName` as inputs
4. Add `harnesscommon.secrets.hasSingleValidESOSecret` 
5. Add `harnesscommon.secrets.isDefaultAppSecret`
6. Fix context argument in `harnesscommon.secrets.manageAppEnv` in call to `harnesscommon.secrets.manageEnv`