### PR TITLE
fix: [SMP-2377]: Create a secret key inside an existing secret if doesnt exist

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
![image](https://github.com/harness/helm-common/assets/105775781/45904fbf-22cf-440e-8d0c-c733d0a9c416)
Currently helm upgrade can fail due to this bug where if there is an existing secret S, it had a,b,c,d secret keys inside it.
If during an upgrade another key e is added, it will fail with an error: key not present.

This PR will fix the issue to create the secret with already existing logic(generate key if not specified, use secret key if specified).

tested on helm upgrade:
Before ( AZURE_APP_CLIENT_SECRET missing)
<img width="627" alt="AWS_ACCOUNT_ID" src="https://github.com/harness/helm-common/assets/105775781/619db7b4-a322-4ab3-a57c-55edea4ca1cf">


After Upgrading(Creates secrets, also other secrets are not impacted):

<img width="650" alt="AWS_ACCOUNT_ID" src="https://github.com/harness/helm-common/assets/105775781/60f9ee46-de9a-4553-9502-99beeeabfe01">

After Upgrading twice(just in case):

<img width="640" alt="AWS_ACCESS_KEY" src="https://github.com/harness/helm-common/assets/105775781/9e52e1af-21b9-419f-bca1-bbd850f2fad0">


