### PR TITLE
Fix: [SMP-2375]: changed function name for waitContainers

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_initContainer.tpl
+++ b/src/common/templates/_initContainer.tpl
@@ -24,7 +24,7 @@ Params:
 {{/*
 
 Create initContainer with wait for label app
-Usage: {{ include "common.initContainer.waitForContainer" (dict "root" . "containerName" "container-name" "appName" "app-name") }}
+Usage: {{ include "harnesscommon.initContainer.waitForContainer" (dict "root" . "containerName" "container-name" "appName" "app-name") }}
 
 Params:
   - values - Object - Required. helm values
@@ -32,7 +32,7 @@ Params:
   - appName - String - Required. name of the app to wait for
 */}}
 
-{{- define "common.initContainer.waitForContainer" -}}
+{{- define "harnesscommon.initContainer.waitForContainer" -}}
 {{- $values := .root.Values }}
 {{- $local := $values.waitForInitContainer }}
 {{- $global := $values.global.waitForInitContainer }}


### PR DESCRIPTION
1. Changed name from `common.initContainer.waitForContainer` to `harnesscommon.initContainer.waitForContainer`
2. Updated chart version (was missed in the previous PR)