### PR TITLE
fix: [SMP-2324]: Bump up chart version for podmonitor changes

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.4
+version: 1.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Bumping up the chart version which was missed in the previous PR