### PR TITLE
feat: [PL-44211]: Add file logging configmap function

### DIFF
--- a/src/common/templates/_logging.tpl
+++ b/src/common/templates/_logging.tpl
@@ -1,0 +1,30 @@
+{{/*
+Set File Logging Config
+Usage example:
+{{- include "harnesscommon.logging.setFileLogging" . }}
+*/}}
+{{- define "harnesscommon.logging.setFileLogging" -}}
+
+{{- $local := .Values.fileLogging }}
+{{- $global := .Values.global.fileLogging }}
+{{- $globalCopy := deepCopy $global }}
+{{- $fileLoggingConfig := $globalCopy }}
+{{- if $local }}
+    {{- $fileLoggingConfig = deepCopy $local | mergeOverwrite $globalCopy }}
+{{- end }}
+{{- if $fileLoggingConfig.enabled }}
+    {{- println "FILE_LOGGING_ENABLED: 'true'" }}
+    {{- if $fileLoggingConfig.logFilename }}
+        {{- printf "FILE_LOGGING_FILENAME: '%s'\n" $fileLoggingConfig.logFilename }}
+    {{- end }}
+    {{- if $fileLoggingConfig.maxFileSize }}
+        {{- printf "FILE_LOGGING_MAX_FILE_SIZE: '%s'\n" $fileLoggingConfig.maxFileSize }}
+    {{- end }}
+    {{- if $fileLoggingConfig.maxBackupFileCount }}
+        {{- printf "LOG_MAX_FILE_COUNT: '%v'\n" $fileLoggingConfig.maxBackupFileCount }}
+    {{- end }}
+    {{- if $fileLoggingConfig.totalFileSizeCap }}
+        {{- printf "LOG_TOTAL_FILE_SIZE_CAP: '%s'\n" $fileLoggingConfig.totalFileSizeCap }}
+    {{- end }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
For the support bundle project, we have added support for storing logs in the pods. To enable this we need to set the fields in the configmap of the service.
This function will give control at both global and service levels to manage the settings.