### PR TITLE
Add helper functions to generate all secrets just using values.yaml

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.15
+version: 1.3.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_dbv3.tpl
+++ b/src/common/templates/_dbv3.tpl
@@ -184,6 +184,7 @@ OPTIONAL:
                 {{- $hosts := $localDBCtx.hosts }}
                 {{- $protocol := $localDBCtx.protocol }}
                 {{- $extraArgs := $localDBCtx.extraArgs }}
+                {{- $database = default $database $localDBCtx.database }}
                 {{- $args := (printf "/%s?%s" $database $extraArgs ) -}}
                 {{- $connectionURI = include "harnesscommon.dbconnection.connection" (dict "type" "mongo" "hosts" $hosts "protocol" $protocol "extraArgs" $args "userVariableName" $userNameEnvName "passwordVariableName" $passwordEnvName)}}
             {{- else if $installed }}


### PR DESCRIPTION
Currently we have to make changes at 4 places, secret.yaml, helpers.tpl, deployment.yaml and values.yaml to just add a secret to a manifest. This makes it hard to add secrets at runtime just using overrides. We should range over the secrets smartly and render

The new file structure of .Secrets should look like:

```
secrets:
  fileSecret:
    - volumeMountPath: "abc"
      keys:
      - TEST_VM_ONE
      - TEST_VM_SEVEN
    - volumeMountPath: "def"
      keys:
      - TEST_VM_TWO
      - TEST_VM_THREE
      - TEST_ESO_TWO
      - TEST_VM_FIVE
      - TEST_VM_FOUR
      - TEST_VM_SIX
  default:
    TEST_VM_ONE: "123"
    TEST_VM_TWO: ""
    TEST_VM_THREE: ""
    TEST_KUBEREXT_TWO: ""
    TEST_VM_SEVEN: ""
  kubernetesSecrets:
    - secretName: "xyz"
      keys:
        TEST_VM_ONE: ""
    - secretName: "def"
      keys:
        TEST_VM_TWO: "def"
        TEST_VM_FIVE: "xyz"
    - secretName: "lmo"
      keys:
        TEST_KUBEREXT_TWO: "lmo"
  secretManagement:
    externalSecretsOperator:
      - secretStore:
          name: "ss-one"
          kind: "clustersecret-one"
        remoteKeys:
          TEST_VM_ONE:
            name: ""
            property: ""
          TEST_KUBEREXT_TWO:
            name: ""
            property: ""
          TEST_VM_TWO:
            name: ""
            property: ""
          TEST_ESO_ONE:
            name: "test"
            property: ""
      - secretStore:
          name: "ss-two"
          kind: "clustersecret-two"
        remoteKeys:
          TEST_ESO_TWO:
            name: "ijk"
            property: ""
      - secretStore:
          name: "ss-four-test"
          kind: "clustersecret-four"
        remoteKeys:
          TEST_VM_FOUR:
            name: "TEST_VM_FOUR_REF"
            property: ""
          TEST_VM_SIX:
            name: "TEST_VM_SIX_REF"
            property: ""
``` 

 On testing the functions:
![image](https://github.com/harness/helm-common/assets/105775781/613892c8-79de-41e0-92b7-41715b258fc0)


it rendered out:
```
---
# Source: mychart/templates/deployment.yaml
#volumeMounts
- name: all-secrets-mount-0
  mountPath: "abc"
- name: all-secrets-mount-1
  mountPath: "def"
#volumes
- name: all-secrets-mount-0
  projected:
    sources:
    - secret:
        name: mychart
        items:
        - key: TEST_VM_ONE
          path: TEST_VM_ONE
        - key: TEST_VM_SEVEN
          path: TEST_VM_SEVEN
- name: all-secrets-mount-1
  projected:
    sources:
    - secret:
        name: mychart
        items:
        - key: TEST_VM_THREE
          path: TEST_VM_THREE
    - secret:
        name: def
        items:
        - key: def
          path: TEST_VM_TWO
        - key: xyz
          path: TEST_VM_FIVE
    - secret:
        name: mychart-ext-secret-1
        items:
        - key: ijk
          path: TEST_ESO_TWO
    - secret:
        name: mychart-ext-secret-2
        items:
        - key: TEST_VM_FOUR_REF
          path: TEST_VM_FOUR
        - key: TEST_VM_SIX_REF
          path: TEST_VM_SIX
#generate secrets in helpers, has unused secrets
TEST_KUBEREXT_TWO: "aEtxamJpczY0YQ=="
TEST_VM_ONE: "MTIz"
TEST_VM_SEVEN: "Q1MzdHRXRzZDRw=="
TEST_VM_THREE: "RFFEbVJSOVFMUQ=="
TEST_VM_TWO: "WjFDUU1jMVBEWQ=="
#render env secrets
- name: TEST_KUBEREXT_TWO
  valueFrom:
    secretKeyRef:
      name: lmo
      key: lmo
- name: TEST_ESO_ONE
  valueFrom:
    secretKeyRef:
      name: mychart-ext-secret-0
      key: TEST_ESO_ONE


``` 

We had to use Projected volumes as volumeMounts cannot happen for different volumes in same directory. And volumes cannot have multiple secret:
https://kubernetes.io/docs/concepts/storage/projected-volumes/ 

