### PR TITLE
Add setting path functionality

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.16
+version: 1.3.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_eso-secrets-helper.tpl
+++ b/src/common/templates/_eso-secrets-helper.tpl
@@ -279,7 +279,6 @@ USAGE:
     {{- range $ind.keys }}
         {{- $fileSecretMap = append $fileSecretMap .key }}
     {{- end}}
-    
 {{- end}}
 {{- $mergedSecretKeys := keys $defaultSecretList $kubernetesSecretsList $ESOSecretsList | uniq }}
 {{- range $key := $mergedSecretKeys }}


### PR DESCRIPTION
before: We didnt have a way to set filePath/ fileName to mounted variable( it was set to the variable name itself)

Added a functionality to have ability to name filenames to variables as well:

the syntax for values.yaml has changed a bit to add list of dictionary instead of list. keeping path empty “” , will lead to path being the variablename(previous  behaviour)
```
keys:
      - key: TEST_VM_ONE
        path: "/abc/deflmo.yaml"
```


Here is the values.yaml
```
secrets:
  fileSecret:
    - volumeMountPath: "abc"
      keys:
      - key: TEST_VM_ONE
        path: "/abc/deflmo.yaml"
      - key: TEST_VM_SEVEN
        path: "/test/foobar.txt"
    - volumeMountPath: "def"
      keys:
      - key: TEST_VM_TWO
        path: "/abc/def"
      - key: TEST_VM_THREE
        path: "/test/foo"
      - key: TEST_ESO_TWO
        path: "/test/bar"
      - key: TEST_VM_FIVE
        path: "/test/some/other"
      - key: TEST_VM_FOUR
        path: "/test/some/othertwo"
      - key: TEST_VM_SIX
        path: ""
  default:
    TEST_VM_ONE: "123"
    TEST_VM_TWO: ""
    TEST_VM_THREE: ""
    TEST_KUBEREXT_TWO: ""
    TEST_VM_SEVEN: ""
  kubernetesSecrets:
    - secretName: "xyz"
      keys:
        TEST_VM_ONE: ""
    - secretName: "def"
      keys:
        TEST_VM_TWO: "def"
        TEST_VM_FIVE: "xyz"
    - secretName: "lmo"
      keys:
        TEST_KUBEREXT_TWO: "lmo"
  secretManagement:
    externalSecretsOperator:
      - secretStore:
          name: "ss-one"
          kind: "clustersecret-one"
        remoteKeys:
          TEST_VM_ONE:
            name: ""
            property: ""
          TEST_KUBEREXT_TWO:
            name: ""
            property: ""
          TEST_VM_TWO:
            name: ""
            property: ""
          TEST_ESO_ONE:
            name: "test"
            property: ""
      - secretStore:
          name: "ss-two"
          kind: "clustersecret-two"
        remoteKeys:
          TEST_ESO_TWO:
            name: "ijk"
            property: ""
      - secretStore:
          name: "ss-four-test"
          kind: "clustersecret-four"
        remoteKeys:
          TEST_VM_FOUR:
            name: "TEST_VM_FOUR_REF"
            property: ""
          TEST_VM_SIX:
            name: "TEST_VM_SIX_REF"
            property: ""
```

Here is the rendered.yaml

```
# Source: mychart/templates/deployment.yaml
#volumeMounts
- name: all-secrets-mount-0
  mountPath: "abc"
- name: all-secrets-mount-1
  mountPath: "def"
#volumes
- name: all-secrets-mount-0
  projected:
    sources:
    - secret:
        name: mychart
        items:
        - key: TEST_VM_ONE
          path: /abc/deflmo.yaml
        - key: TEST_VM_SEVEN
          path: /test/foobar.txt
- name: all-secrets-mount-1
  projected:
    sources:
    - secret:
        name: mychart
        items:
        - key: TEST_VM_THREE
          path: /test/foo
    - secret:
        name: def
        items:
        - key: def
          path: /abc/def
        - key: xyz
          path: /test/some/other
    - secret:
        name: mychart-ext-secret-1
        items:
        - key: ijk
          path: /test/bar
    - secret:
        name: mychart-ext-secret-2
        items:
        - key: TEST_VM_FOUR_REF
          path: /test/some/othertwo
        - key: TEST_VM_SIX_REF
          path: TEST_VM_SIX
#generate secrets in helpers, has unused secrets
TEST_KUBEREXT_TWO: "U3l6eFJaNFBvUg=="
TEST_VM_ONE: "MTIz"
TEST_VM_SEVEN: "UzRkSEVHS3Z4WA=="
TEST_VM_THREE: "eXVZMFZKMlNpdA=="
TEST_VM_TWO: "S1pNd2hUT3pEMA=="
#render env secrets
- name: TEST_KUBEREXT_TWO
  valueFrom:
    secretKeyRef:
      name: lmo
      key: lmo
- name: TEST_ESO_ONE
  valueFrom:
    secretKeyRef:
      name: mychart-ext-secret-0
      key: TEST_ESO_ONE
``` 

