### PR TITLE
feat: [PL-48522]: Support a helm template function for ingress rule

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.23
+version: 1.3.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -1,0 +1,73 @@
+{{/*
+USAGE:
+{{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}
+*/}}
+{{- define "harnesscommon.v1.renderIngress" }}
+{{- $ := .ctx }}
+{{- if $.Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- if $.Values.global.commonLabels }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if $.Values.ingress.annotations }}
+    {{- include "harnesscommon.tplvalues.render" (dict "value" $.Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if $.Values.global.commonAnnotations }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if $.Values.global.ingress.objects.annotations }}
+    {{- include "harnesscommon.tplvalues.render" (dict "value" $.Values.global.ingress.objects.annotations "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $.Values.global.ingress.className | quote }}
+  rules:
+    {{- if $.Values.global.ingress.disableHostInIngress }}
+    - http:
+        paths:
+        {{- range $idx := $.Values.ingress.paths }}
+        {{- $serviceName := dig "backend" "service" "name" $.Chart.Name $idx }}
+        {{- $servicePort := dig "backend" "service" "port" $.Values.service.port $idx }}
+        {{- $pathType := dig "pathType" "ImplementationSpecific" $idx }}
+        - backend:
+            service:
+              name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
+          path: {{ $idx.path }}
+          pathType: {{ $pathType }}
+        {{- end }}
+    {{- else }}
+    {{- range $.Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+        {{- range $idx := $.Values.ingress.paths }}
+        {{- $serviceName := dig "backend" "service" "name" $.Chart.Name $idx }}
+        {{- $servicePort := dig "backend" "service" "port" $.Values.service.port $idx }}
+        {{- $pathType := dig "pathType" "ImplementationSpecific" $idx }}
+        - backend:
+            service:
+              name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
+          path: {{ $idx.path }}
+          pathType: {{ $pathType }}
+        {{- end }}
+    {{- end }}
+    {{- end}}
+  {{- if $.Values.global.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- range $.Values.global.ingress.hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ $.Values.global.ingress.tls.secretName }}
+  {{- end }}
+{{- end }}
+
+{{- end}}

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -38,7 +38,7 @@ spec:
               name: {{ $serviceName }}
               port:
                 number: {{ $servicePort }}
-          path: {{ $idx.path }}
+          path: {{ include "harnesscommon.tplvalues.render" ( dict "value" $idx.path "context" $) }}
           pathType: {{ $pathType }}
         {{- end }}
     {{- else }}
@@ -69,5 +69,4 @@ spec:
       secretName: {{ $.Values.global.ingress.tls.secretName }}
   {{- end }}
 {{- end }}
-
-{{- end}}
+{{- end }}


### PR DESCRIPTION
Motivation for change:
- we did not have the capability to remove host from ingress rules. It caused issues if it is deployed alongside nonhost ingress rules

Change the ingress rule to be a one-liner:
```
{{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}
```

added fields:
```
global:
  ingress:
    disableHostInIngress: false <-- disables hostname in ingress rules
    pathPrefix: "xyz".  <-- does not do anything, but your path can reference this.
```

```
ingress:
  annotations: 
    nginx.ingress.kubernetes.io/rewrite-target: /$2
  paths:
  - path: /authz(/|$)(.*)
  - path: /newpath(/|$)(.*)
  - path: '{{ .Values.global.ingress.pathPrefix}}/gateway/api'
    pathType: Prefix
    backend:
      service:
        port: 9006
        name: youCanProvideJustNameLikeThis
```
For SMP:
we need to take care of the following:
- move the annotations from ingress file(hardcoded) to values.ingress.annotations
- all the rules from ingress needs to move from harcoded paths to .Values.ingress.paths