### PR TITLE
Add ability to configure multiple ingress objects

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.26
+version: 1.3.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -9,7 +9,7 @@ USAGE:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}-{{$idx}}
+  name: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}-{{ $idx }}
   namespace: {{ $.Release.Namespace }}
   {{- if $.Values.global.commonLabels }}
   labels:

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -5,11 +5,11 @@ USAGE:
 {{- define "harnesscommon.v1.renderIngress" }}
 {{- $ := .ctx }}
 {{- if $.Values.global.ingress.enabled -}}
-{{- range $idx, $object := $.Values.ingress.objects }}
+{{- range $index, $object := $.Values.ingress.objects }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}-{{ $idx }}
+  name: {{ dig "name" ((cat (default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-") "-" $index)| nospace)  $object }}
   namespace: {{ $.Release.Namespace }}
   {{- if $.Values.global.commonLabels }}
   labels:


### PR DESCRIPTION
Added ability to configure multiple ingress objects.

```
global:
  ingress:
    disableHostInIngress: false
    pathPrefix: ""
    pathType: ""
```

```
ingress:
  objects:
    - annotations: 
        nginx.ingress.kubernetes.io/rewrite-target: /$2
      paths:
      - path: '{{ .Values.global.ingress.pathPrefix }}/pipeline(/|$)(.*)'
    - name: pipeline-service-v1-apis
      annotations: 
        nginx.ingress.kubernetes.io/rewrite-target: /api/$1
      paths:
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines.*)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/input-sets.*)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/pipeline-schema.*)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines/.+/execute/stages-execution-list)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines/.+/execute/stages)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines/.+/execute)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/step-pallete)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/triggers/catalog)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/approvals/.+)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines/.+/triggers)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/pipelines/.+/triggers/.+)'
      - path: '{{ .Values.global.ingress.pathPrefix }}/(v1/orgs/.+/projects/.+/execution/.+)'
```