### PR TITLE
Fix secret ref if the secret contains hyphens

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.36
+version: 1.3.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_eso-secrets-helper.tpl
+++ b/src/common/templates/_eso-secrets-helper.tpl
@@ -220,13 +220,13 @@ spec:
       data:
         {{- range $remoteKeyName, $remoteKey := $esoSecret.remoteKeys }}
           {{- if not (empty $remoteKey.name) }}
-        {{ $remoteKeyName }}: "{{ printf "{{ .%s }}" (lower $remoteKeyName) }}"
+        {{ $remoteKeyName }}: "{{ printf "{{ .%s }}" (lower $remoteKeyName | replace "-" "_") }}"
           {{- end }}
         {{- end }}
   data:
   {{- range $remoteKeyName, $remoteKey := $esoSecret.remoteKeys }}
     {{- if not (empty $remoteKey.name) }}
-  - secretKey: {{ lower $remoteKeyName }}
+  - secretKey: {{ lower $remoteKeyName | replace "-" "_" }}
     remoteRef:
       key: {{ $remoteKey.name }}
       {{- if not (empty $remoteKey.property) }}


### PR DESCRIPTION
Current behaviour: if the secret contained a hyphen, the externalsecret does translate the secret into the k8s object.
This PR fixes it. 
More details here: https://github.com/external-secrets/external-secrets/issues/1053
its a golang template limitation