### PR TITLE
Fixing timescale templates to use argument first for protocol.

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.50
+version: 1.3.51
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnectionsv2.tpl
+++ b/src/common/templates/_databaseconnectionsv2.tpl
@@ -142,10 +142,11 @@ USAGE:
     {{- $protocol := "" }}
     {{- if not (empty .protocol) }}
         {{- $protocol = (printf "%s://" .protocol) }}
-    {{- end }}
-    {{- $protocolVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" .context "valueType" "string" "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
-    {{- if not (empty $protocolVar) }}
-        {{- $protocol = (printf "%s://" $protocolVar) }}
+    {{- else }}
+        {{- $protocolVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" .context "valueType" "string" "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
+        {{- if not (empty $protocolVar) }}
+            {{- $protocol = (printf "%s://" $protocolVar) }}
+        {{- end }}
     {{- end }}
     {{- $userAndPassField := "" }}
     {{- if and (.userVariableName) (.passwordVariableName) }}

--- a/src/common/templates/_dbv3.tpl
+++ b/src/common/templates/_dbv3.tpl
@@ -707,10 +707,11 @@ USAGE:
     {{- $protocol := "" }}
     {{- if not (empty .protocol) }}
         {{- $protocol = (printf "%s://" .protocol) }}
-    {{- end }}
-    {{- $protocolVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" .context "valueType" "string" "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
-    {{- if not (empty $protocolVar) }}
-        {{- $protocol = (printf "%s://" $protocolVar) }}
+    {{- else }}
+        {{- $protocolVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" .context "valueType" "string" "keys" (list ".Values.global.database.timescaledb.protocol" ".Values.timescaledb.protocol"))) }}
+        {{- if not (empty $protocolVar) }}
+            {{- $protocol = (printf "%s://" $protocolVar) }}
+        {{- end }}
     {{- end }}
     {{- $userAndPassField := "" }}
     {{- if and (.userVariableName) (.passwordVariableName) }}


### PR DESCRIPTION
Existing timescale functions v2 and v3 will now set protocol based on the argument first then from the values. This will avoid breaking changes to helm charts that have not been updated and maybe relying on default values.

Charts moving forward should update to v4 which will only read it from the arugment.