### PR TITLE
feat: [PL-56708]: adding PDB function

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.54
+version: 1.3.55
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_pdb.tpl
+++ b/src/common/templates/_pdb.tpl
@@ -1,0 +1,47 @@
+{{/*
+Create Pod Distribution Budget Configurations
+Usage example:
+{{- include "harnesscommon.pdb.renderPodDistributionBudget" . }}
+*/}}
+{{- define "harnesscommon.pdb.renderPodDistributionBudget" -}}
+{{- $ := .ctx }}
+{{- if or $.Values.global.pdb.create $.Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
+  namespace: {{ $.Release.Namespace }}
+  {{- if $.Values.global.commonLabels }}
+  labels: {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.global.commonAnnotations }}
+  annotations: {{- include "harnesscommon.tplvalues.render" ( dict "value" .Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- $minAvailable := "50%" }}
+  {{- $maxUnavailable := "" }}
+
+  {{- if $.Values.global.pdb.minAvailable }}
+      {{- $minAvailable = $.Values.global.pdb.minAvailable }}
+  {{- end }}
+  {{- if $.Values.pdb.minAvailable }}
+      {{- $minAvailable = $.Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if $.Values.global.pdb.maxUnavailable }}
+      {{- $maxUnavailable = $.Values.global.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if $.Values.pdb.maxUnavailable }}
+      {{- $maxUnavailable = $.Values.pdb.maxUnavailable }}
+  {{- end }}
+
+  {{- if $minAvailable }}
+  minAvailable: {{ $minAvailable }}
+  {{- end }}
+  {{- if $maxUnavailable }}
+  maxUnavailable: {{ $maxUnavailable }}
+  {{- end }}
+  {{- $selectorFunction := printf "%s.selectorLabels" $.Chart.Name }}
+  selector:
+    matchLabels: {{ include $selectorFunction $ | nindent 6 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Pod Disruption Budgets are not configurable and for most of the services are set at `minAvailable: 50%`, customers require an option to configure PDBs for all services and the ability to turn them off or on.
This PR adds a helm function that will be used by all services to render the PDB manifest and is configurable through the override file.
The configuration is divided into two parts
- Global: Global configurations will be applied to all services
- Local: These have precedence over global config and can be used to specifically set values for the PDB of a service.

