### PR TITLE
fix: [PL-57361]: support multipe ingress definitions

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.61
+version: 1.3.62
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -1,15 +1,21 @@
 {{/*
 USAGE:
 {{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}
+or
+{{- include "harnesscommon.v1.renderIngress" (dict "ingress" .Values.other.ingress "ctx" $) }}
 */}}
 {{- define "harnesscommon.v1.renderIngress" }}
 {{- $ := .ctx }}
+{{- $ingress := $.Values.ingress }}
+{{- if .ingress -}}
+    {{- $ingress = .ingress }}
+{{- end }}
 {{- if $.Values.global.ingress.enabled -}}
-{{- range $index, $object := $.Values.ingress.objects }}
+{{- range $index, $object := $ingress.objects }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ dig "name" ((cat (default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-") "-" $index)| nospace)  $object }}
+  name: {{ dig "name" ((cat (coalesce $ingress.name $.Values.nameOverride $.Chart.Name | trunc 63 | trimSuffix "-") "-" $index) | nospace) $object }}
   namespace: {{ $.Release.Namespace }}
   {{- if $.Values.global.commonLabels }}
   labels:
@@ -17,8 +23,8 @@ metadata:
   {{- end }}
   annotations:
     {{- include "harnesscommon.tplvalues.render" (dict "value" $object.annotations "context" $) | nindent 4 }}
-    {{- if $.Values.ingress.annotations }}
-    {{- include "harnesscommon.tplvalues.render" (dict "value" $.Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- if $ingress.annotations }}
+    {{- include "harnesscommon.tplvalues.render" (dict "value" $ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if $.Values.global.commonAnnotations }}
     {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonAnnotations "context" $ ) | nindent 4 }}


### PR DESCRIPTION
The ingress template function should allow us to define multiple ingress objects. This allows applications to conditionally render different ingress objects for different needs.

This change is fully backward compatible.

Example,
`values.yaml`
```yaml
ingress:
  objects:
  - annotations:
      nginx.ingress.kubernetes.io/rewrite-target: /$2
    paths:
    - path: '{{ .Values.global.ingress.pathPrefix}}/cdc(/|$)(.*)'
pms:
  ingress:
    name: change-data-capture-pms
    objects:
    - annotations:
        nginx.ingress.kubernetes.io/rewrite-target: /$2
      paths:
      - path: '{{ .Values.global.ingress.pathPrefix}}/cdc(/|$)(/sync/pipelines.*)'
        enabled: splitDeployment.enabled
        backend:
          service:
            name: change-data-capture-pms

```
`ingress.yaml`
```yaml
{{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}

{{- if .Values.splitDeployment.enabled }}
  {{- include "harnesscommon.v1.renderIngress" (dict "ingress" .Values.pms.ingress "ctx" $) }}
{{- end }}

```