### PR TITLE
feat: [PL-57710]: added function to template HPA

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.64
+version: 1.3.65
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_hpa.tpl
+++ b/src/common/templates/_hpa.tpl
@@ -54,30 +54,45 @@ Required because there was a change between supported versions
 {{- include "harnesscommon.hpa.metrics.apiVersion" . }}
 */}}
 {{- define "harnesscommon.hpa.metrics.apiVersion" -}}
-  {{- if or .Values.autoscaling.targetMemory .Values.autoscaling.targetCPU }}
+  {{- $targetMemory := "" }}
+  {{- $targetCPU := "" }}
+
+  {{- if $.Values.global.autoscaling.targetMemory }}
+      {{- $targetMemory = $.Values.global.autoscaling.targetMemory }}
+  {{- end }}
+  {{- if $.Values.autoscaling.targetMemory }}
+      {{- $targetMemory = $.Values.autoscaling.targetMemory }}
+  {{- end }}
+  {{- if $.Values.global.autoscaling.targetCPU }}
+      {{- $targetCPU = $.Values.global.autoscaling.targetCPU }}
+  {{- end }}
+  {{- if $.Values.autoscaling.targetCPU }}
+      {{- $targetCPU = $.Values.autoscaling.targetCPU }}
+  {{- end }}
+  {{- if or $targetMemory $targetCPU }}
   metrics:
-    {{- if .Values.autoscaling.targetMemory }}
+    {{- if $targetMemory }}
     - type: Resource
       resource:
         name: memory
         {{- if semverCompare "<1.23-0" (include "harnesscommon.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemory }}
+        targetAverageUtilization: {{ $targetMemory }}
         {{- else }}
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemory }}
+          averageUtilization: {{ $targetMemory }}
         {{- end }}
     {{- end }}
-    {{- if .Values.autoscaling.targetCPU }}
+    {{- if $targetCPU }}
     - type: Resource
       resource:
         name: cpu
         {{- if semverCompare "<1.23-0" (include "harnesscommon.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+        targetAverageUtilization: {{ $targetCPU }}
         {{- else }}
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPU }}
+          averageUtilization: {{ $targetCPU }}
         {{- end }}
     {{- end }}
   {{- end }}

--- a/src/common/templates/_hpa.tpl
+++ b/src/common/templates/_hpa.tpl
@@ -1,3 +1,58 @@
+{{/*
+Create Horizontal Pod Autoscaler Configuration
+Usage example:
+{{- include "harnesscommon.hpa.renderHPA" . (dict "ctx" .  "kind" "deployment") }}
+*/}}
+{{- define "harnesscommon.hpa.renderHPA" -}}
+{{- $ := .ctx }}
+{{- if or $.Values.global.autoscaling.enabled $.Values.autoscaling.enabled }}
+{{- $labelsFunction := printf "%s.labels" (default $.Chart.Name $.Values.nameOverride) }}
+{{- $serviceName := default $.Chart.Name $.Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $minReplicas := 2 }}
+{{- $maxReplicas := 100 }}
+
+{{- if $.Values.global.autoscaling.minReplicas }}
+    {{- $minReplicas = $.Values.global.autoscaling.minReplicas }}
+{{- end }}
+{{- if $.Values.autoscaling.minReplicas }}
+    {{- $minReplicas = $.Values.autoscaling.minReplicas }}
+{{- end }}
+{{- if $.Values.global.autoscaling.maxReplicas }}
+    {{- $maxReplicas = $.Values.global.autoscaling.maxReplicas }}
+{{- end }}
+{{- if $.Values.autoscaling.maxReplicas }}
+    {{- $maxReplicas = $.Values.autoscaling.maxReplicas }}
+{{- end }}
+apiVersion: {{ include "harnesscommon.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include $labelsFunction $ | nindent 4 }}
+    {{- if $.Values.global.commonLabels }}
+    {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.global.commonAnnotations }}
+  annotations: {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ .kind }}
+    name: {{ $serviceName }}
+  minReplicas: {{ $minReplicas }}
+  maxReplicas: {{ $maxReplicas }}
+  {{- include "harnesscommon.hpa.metrics.apiVersion" $ }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Define targetCPU and targetMemory based on K8s version
+Required because there was a change between supported versions
+{{- include "harnesscommon.hpa.metrics.apiVersion" . }}
+*/}}
 {{- define "harnesscommon.hpa.metrics.apiVersion" -}}
   {{- if or .Values.autoscaling.targetMemory .Values.autoscaling.targetCPU }}
   metrics:


### PR DESCRIPTION
## Changes
Through this PR we are centralising the HPA configuration. This will add support for the following:
- Add HPA control at both global and service level
- `global.autoscaling.enabled` will have higher precedence over `autoscaling.enabled`
- For `minReplicas` and `maxReplicas`, we won’t have any service-level defaults.
- If service level overrides are set for `minReplicas` and `maxReplicas`, they will have higher precedence over global
- For `targetCPU` and `targetMemory`, service level overrides will have higher precedence over global, same as min/max repliacs.


This way, anyone can fine-tune service-level overrides for minReplicas, maxReplicas, targetCPU and targetMemory

Through helm-charts global override, these default values will be set for all services
```
global:
  autoscaling:
    enabled: false
    minReplicas: 2
    maxReplicas: 100
    targetCPU: "80%"
    targetMemory: "80%"
```

Apart from this, the values are configurable at the service level
```
autoscaling:
    enabled: false
    minReplicas: 2
    maxReplicas: 100
    targetCPU: "80%"
    targetMemory: "80%"
    behavior: {}
```

## Testing
Screenshot of different configurations

- With service level override
![Screenshot 2024-10-23 at 11 52 35 AM](https://github.com/user-attachments/assets/2bbb5360-9276-43be-9093-06366b14e1c0)

- With global overrides
![Screenshot 2024-10-23 at 11 53 42 AM](https://github.com/user-attachments/assets/e057e11a-d83d-464b-96d5-755e6b4bf555)

- With both global and service overrides
![Screenshot 2024-10-23 at 11 53 11 AM](https://github.com/user-attachments/assets/91c33dd8-538d-41a3-9e1c-3d78834b7d5e)


Test results from unit-test covering all combinations.
![Screenshot 2024-10-23 at 11 55 24 AM](https://github.com/user-attachments/assets/efc66124-8253-4e56-90aa-c34adac1552e)

