### PR TITLE
feat: [OPS-31399]: Added capability for database to be overriden

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.66
+version: 1.3.67
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnectionsv2.tpl
+++ b/src/common/templates/_databaseconnectionsv2.tpl
@@ -130,6 +130,7 @@ USAGE:
 {{ include "harnesscommon.dbconnectionv2.timescaleConnection" (dict "database" "foo" "args" "bar" "context" $ "addSSLModeArg" false) }}
 */}}
 {{- define "harnesscommon.dbconnectionv2.timescaleConnection" }}
+    {{- $database := default .database .context.Values.timescaledb.database }}
     {{- $addSSLModeArg := default false .addSSLModeArg }}
     {{- $sslEnabled := false }}
     {{- $sslEnabledVar := (include "harnesscommon.precedence.getValueFromKey" (dict "ctx" .context "valueType" "bool" "keys" (list ".Values.global.database.timescaledb.sslEnabled" ".Values.timescaledb.sslEnabled"))) }}
@@ -152,7 +153,7 @@ USAGE:
     {{- if and (.userVariableName) (.passwordVariableName) }}
         {{- $userAndPassField = (printf "$(%s):$(%s)@" .userVariableName .passwordVariableName) }}
     {{- end }}
-    {{- $connectionString = (printf "%s%s%s:%s/%s" $protocol $userAndPassField  $host $port .database) }}
+    {{- $connectionString = (printf "%s%s%s:%s/%s" $protocol $userAndPassField  $host $port $database) }}
     {{- if .args }}
         {{- if $addSSLModeArg }}
             {{- if $sslEnabled }}

--- a/src/common/templates/_dbv3.tpl
+++ b/src/common/templates/_dbv3.tpl
@@ -701,6 +701,7 @@ USAGE:
     {{- if .localTimescaleDBCtx }}
         {{- $localTimescaleDBCtx = .localTimescaleDBCtx }}
     {{- end }}
+    {{- $database := default .database $localTimescaleDBCtx.database }}
     {{- $host := include "harnesscommon.dbconnectionv3.timescaleHost" (dict "context" .context "localTimescaleDBCtx" $localTimescaleDBCtx ) }}
     {{- $port := include "harnesscommon.dbconnectionv3.timescalePort" (dict "context" .context "localTimescaleDBCtx" $localTimescaleDBCtx ) }}
     {{- $connectionString := "" }}
@@ -717,7 +718,7 @@ USAGE:
     {{- if and (.userVariableName) (.passwordVariableName) }}
         {{- $userAndPassField = (printf "$(%s):$(%s)@" .userVariableName .passwordVariableName) }}
     {{- end }}
-    {{- $connectionString = (printf "%s%s%s:%s/%s" $protocol $userAndPassField  $host $port .database) }}
+    {{- $connectionString = (printf "%s%s%s:%s/%s" $protocol $userAndPassField  $host $port $database) }}
     {{- if .args }}
         {{- if $addSSLModeArg }}
             {{- if $sslEnabled }}


### PR DESCRIPTION
The database name can be controlled from overrides by adding below:

```
timescaledb:
  database: "harness_free"

secondaryTimescaledb:
  database: "harness_free"
```

We didnt update the helper argument to avoid breaking existing charts.
@arya-harness to review.
