### PR TITLE
feat: [PL-58202]: Add support for OSS managed Prometheus instance, misc fixes

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.68
+version: 1.3.69
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
- Add Support for OSS Prometheus CRD: https://github.com/helm/charts/blob/master/stable/prometheus-operator/crds/crd-podmonitor.yaml, Example: https://github.com/bitnami/charts/blob/main/bitnami/redis/templates/podmonitor.yaml
- Add Support for All fields to be dynamically generated with backward compatibility.
- Add ability to change name of podMonitoring. cc: @manishjaiswal2 

**Test cases:**
**tested with following override**
```monitoring:
  port: 8889
  path: /metrics
  additionalPodMonitorSpec:
    sampleLimit: 20
  additionalPodMetricsEndpoints:
  - port: "9000"
    interval: 2000s
    path: "/metrics"
  PodMetricsEndpointsConfig:
    honorLabels: "xyz"
 ```
 **Renders**
   
 ```
 # Source: harness-manager/templates/podmonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: harness-manager-iterator
  namespace: default
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: harness-manager-iterator
  podMetricsEndpoints:
    - port: "8889"
      interval: 120s
      path: "/metrics"
      honorLabels: xyz
    - interval: 2000s
      path: /metrics
      port: "9000"
  sampleLimit: 20
  ```   