### PR TITLE
Add ability to support otel in all charts with monitoring enabled, fix pg port function

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,6 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-
 version: 1.3.79
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.76
+version: 1.3.77
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_databaseconnectionsv2.tpl
+++ b/src/common/templates/_databaseconnectionsv2.tpl
@@ -772,3 +772,36 @@ Define environment variable value based on ENABLE_ELASTIC
   {{- printf "%s" (split ":" (index $hosts 0))._0 }}
   {{- end }}
 {{- end }}
+
+
+{{- define "harnesscommon.dbconnectionv3.postgresPort" }}
+{{- $ := .context }}
+{{- $connectionString := "" }}
+{{- $globalDBCtx := $.Values.global.database.postgres }}
+  {{- if .globalDBCtx }}
+      {{- $globalDBCtx = .globalDBCtx }}
+  {{- end }}
+{{- $type := "postgres" }}
+{{- $localDBCtx := $.Values.postgres }}
+{{- if .localDBCtx }}
+    {{- $localDBCtx = .localDBCtx }}
+{{- end }}
+{{- $installed := false }}
+  {{- if eq $globalDBCtx.installed true }}
+      {{- $installed = $globalDBCtx.installed }}
+  {{- end }}
+  {{- if eq $localDBCtx.enabled true }}
+      {{- $installed = false }}
+  {{- end }}
+{{- if $installed }}
+    {{- print "postgres" }}
+{{- else }}
+    {{- $hosts := list }}
+    {{- if gt (len $localDBCtx.hosts) 0 }}
+        {{- $hosts = $localDBCtx.hosts }}
+    {{- else }}
+        {{- $hosts = $globalDBCtx.hosts }}
+    {{- end }}
+{{- printf "%s" (split ":" (index $hosts 0))._1 }}
+{{- end }}
+{{- end }}

--- a/src/common/templates/_monitoring.tpl
+++ b/src/common/templates/_monitoring.tpl
@@ -9,6 +9,16 @@
 {{- $port := (pluck "port" $monitoring) | first -}}
 ENABLE_PROMETHEUS_COLLECTOR: {{ default "false" $enabled | quote }}
 PROMETHEUS_COLLECTOR_PORT: {{ default "8889" $port | quote }}
+{{- $otelEnabled := default false (or ((.Values.monitoring).otel).enabled (((.Values.global).monitoring).otel).enabled) }}
+{{- $enableOtelVariable := default "ENABLE_OPENTELEMETRY" .enableOtelVariable }}
+{{- $otelCollectorEndpoint := default "http://opentelemetry-collector-service.otel.svc.cluster.local:4317/" (default (((.Values.global).monitoring).otel).collectorEndpoint ((.Values.monitoring).otel).collectorEndpoint) }}
+{{- $otelCollectorVariable := default "OTEL_EXPORTER_OTLP_ENDPOINT" .otelCollectorVariable }}
+{{- $otelServiceNameVariable := default "OTEL_SERVICE_NAME" .otelServiceNameVariable}}
+{{- if $otelEnabled }}
+{{- printf "\n%s: '%s'" $otelCollectorVariable $otelCollectorEndpoint}}
+{{- printf "\n%s: '%s'" $otelServiceNameVariable .Chart.Name }}
+{{- printf "\n%s: '%t'" $enableOtelVariable $otelEnabled }}
+{{- end }}
 {{- end -}}
 
 {{/* Generates monitoring annotations to be added all deployments


### PR DESCRIPTION
Add ability to set opentelemetry variables under the conditions of monitoring.otel.enabled or global.monitoring.otel.enabled
```
global:
  monitoring:
    enabled: true
    managedPlatform: google
    otel:
      enabled: true
      collectorEndpoint: "https://abcd:4317/"

monitoring:
  otel:
    enabled: true
    collectorEndpoint: "https://defg:4317/"
```

![image](https://github.com/user-attachments/assets/ce8c3178-1dbc-454c-85ac-97c4e9839d6d)
![image](https://github.com/user-attachments/assets/100726aa-48fe-4af3-a90b-a96043b6f03e)

