### PR TITLE
fix: [PL-60135]: helm common image function to support Digest and Tag

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.76
+version: 1.3.77
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/common/templates/_images.tpl
+++ b/src/common/templates/_images.tpl
@@ -10,16 +10,32 @@ Return the proper image name
 {{- $registryName := .imageRoot.registry -}}
 {{- $repositoryName := .imageRoot.repository -}}
 {{- $separator := ":" -}}
-{{- $termination := .imageRoot.tag | toString -}}
+{{- $termination := "" -}}
 {{- $ignoreGlobalImageRegistry := default false .imageRoot.ignoreGlobalImageRegistry }}
+{{- $tag := .imageRoot.tag | toString | default "" -}}
+{{- $digest := .imageRoot.digest | toString | default "" -}}
+{{- $preferDigest := default false .imageRoot.preferDigest }} # Default to not preferring digest unless specified
 {{- if .global }}
     {{- if and .global.imageRegistry (not $ignoreGlobalImageRegistry) }}
      {{- $registryName = .global.imageRegistry -}}
     {{- end -}}
 {{- end -}}
-{{- if .imageRoot.digest }}
+{{- if and (ne $tag "") (ne $digest "") }}
+    {{- if $preferDigest }}
+        {{- $separator = "@" -}}
+        {{- $termination = $digest -}}
+    {{- else }}
+        {{- $separator = ":" -}}
+        {{- $termination = $tag -}}
+    {{- end -}}
+{{- else if ne $digest "" }}
     {{- $separator = "@" -}}
-    {{- $termination = .imageRoot.digest | toString -}}
+    {{- $termination = $digest -}}
+{{- else if ne $tag "" }}
+    {{- $separator = ":" -}}
+    {{- $termination = $tag -}}
+{{- else }}
+    {{- fail "Error: Either tag or digest must be provided for the image!" -}}
 {{- end -}}
 {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
 {{- end -}}

--- a/src/common/templates/_images.tpl
+++ b/src/common/templates/_images.tpl
@@ -22,6 +22,9 @@ Return the proper image name
 {{- end -}}
 {{- if and (ne $tag "") (ne $digest "") }}
     {{- if $preferDigest }}
+        {{- if not (hasPrefix "sha256:" $digest) }}
+            {{- fail (printf "Error: Digest must start with 'sha256:', got '%s'" $digest) -}}
+        {{- end -}}
         {{- $separator = "@" -}}
         {{- $termination = $digest -}}
     {{- else }}
@@ -29,6 +32,9 @@ Return the proper image name
         {{- $termination = $tag -}}
     {{- end -}}
 {{- else if ne $digest "" }}
+    {{- if not (hasPrefix "sha256:" $digest) }}
+        {{- fail (printf "Error: Digest must start with 'sha256:', got '%s'" $digest) -}}
+    {{- end -}}
     {{- $separator = "@" -}}
     {{- $termination = $digest -}}
 {{- else if ne $tag "" }}


### PR DESCRIPTION
Flow - 
1. If only one of digest or tag is present, use it
2. If none are present, throw an error
3. If both are present, use the flag `preferDigest` to decide which to use. Default for `preferDigest` is false.

Also check if the digest format is correct - 
```
gokulbansal@Gokul Bansal chart % helm template . > output.yaml
Error: execution error at (ng-manager/templates/deployment.yaml:63:18): Error: Digest must start with 'sha256:', got 'sha26:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a'

Use --debug flag to render out invalid YAML

```

Test cases -    

1. Both image and tog not present
2. Only image tag present
```
image:
  registry: us.gcr.io/platform-205701
  repository: ng-manager
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: "1.19.2"
  digest: ""
  imagePullSecrets: []
  ```
  ```
  containers:
- name: ng-manager
  image: us.gcr.io/platform-205701/ng-manager:1.19.2
  imagePullPolicy: IfNotPresent
  securityContext:
      runAsNonRoot: true
      runAsUser: 65534
  ```

3. Only image digest present
```
image:
  registry: us.gcr.io/platform-205701
  repository: ng-manager
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: ""
  digest: "sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a"
  imagePullSecrets: []
```
```
containers:
- name: ng-manager
  image: us.gcr.io/platform-205701/ng-manager@sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a
```
4. Both present but no flag present
```
image:
  registry: us.gcr.io/platform-205701
  repository: ng-manager
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: "1.19.2"
  digest: "sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a"
  imagePullSecrets: []
```
```
containers:
- name: ng-manager
  image: us.gcr.io/platform-205701/ng-manager:1.19.2
```
5. Both present but preferDigest flag is set to false
```
image:
  registry: us.gcr.io/platform-205701
  repository: ng-manager
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: "1.19.2"
  digest: "sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a"
  imagePullSecrets: []
  preferDigest: false
```
```
containers:
- name: ng-manager
  image: us.gcr.io/platform-205701/ng-manager:1.19.2
```
6. Both present but preferDigest flag is set to true
```
image:
  registry: us.gcr.io/platform-205701
  repository: ng-manager
  pullPolicy: IfNotPresent
  # Overrides the image tag whose default is the chart appVersion.
  tag: "1.19.2"
  digest: "sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a"
  imagePullSecrets: []
  preferDigest: true
```
```
containers:
- name: ng-manager
  image: us.gcr.io/platform-205701/ng-manager@sha256:52a3a0578d956aa2283c3adf6bcaf86edeeb68be74b6ea4d4236df683547d37a
```