### PR TITLE
Update prefer digest image function to solve nil error

### DIFF
--- a/src/common/templates/_images.tpl
+++ b/src/common/templates/_images.tpl
@@ -12,8 +12,14 @@ Return the proper image name
 {{- $separator := ":" -}}
 {{- $termination := "" -}}
 {{- $ignoreGlobalImageRegistry := default false .imageRoot.ignoreGlobalImageRegistry }}
-{{- $tag := .imageRoot.tag | toString | default "" -}}
-{{- $digest := .imageRoot.digest | toString | default "" -}}
+{{- $digest := "" -}}
+{{- if hasKey .imageRoot "digest" -}}
+  {{- $digest = .imageRoot.digest | default "" -}}
+{{- end -}}
+{{- $tag := "" -}}
+{{- if hasKey .imageRoot "tag" -}}
+  {{- $tag = .imageRoot.tag | default "" -}}
+{{- end -}}
 {{- $preferDigest := default false .global.preferDigest }}
 {{- if .global }}
     {{- if and .global.imageRegistry (not $ignoreGlobalImageRegistry) }}

--- a/src/common/templates/_images.tpl
+++ b/src/common/templates/_images.tpl
@@ -12,14 +12,8 @@ Return the proper image name
 {{- $separator := ":" -}}
 {{- $termination := "" -}}
 {{- $ignoreGlobalImageRegistry := default false .imageRoot.ignoreGlobalImageRegistry }}
-{{- $digest := "" -}}
-{{- if hasKey .imageRoot "digest" -}}
-  {{- $digest = .imageRoot.digest | default "" -}}
-{{- end -}}
-{{- $tag := "" -}}
-{{- if hasKey .imageRoot "tag" -}}
-  {{- $tag = .imageRoot.tag | default "" -}}
-{{- end -}}
+{{- $tag := default "" .imageRoot.tag -}}
+{{- $digest := default "" .imageRoot.digest -}}
 {{- $preferDigest := default false .global.preferDigest }}
 {{- if .global }}
     {{- if and .global.imageRegistry (not $ignoreGlobalImageRegistry) }}


### PR DESCRIPTION
[ERROR] [deployNamespace.sh] Helm deployment for harness failed
Error: UPGRADE FAILED: execution error at (harness/charts/platform/charts/bootstrap/charts/database/charts/timescaledb/templates/cronjob-archivecleanup.yaml:34:22): Error: Digest must start with 'sha256:', got '\<nil\>'

Getting this error when image.digest key is not present.

Tested with templating the helm package with changes and didn't get the error again.