### PR TITLE
feat: [CLI-51461]: implementing checks to allow upgrade to ES v1 API

### DIFF
--- a/src/common/templates/_dbv3.tpl
+++ b/src/common/templates/_dbv3.tpl
@@ -231,7 +231,7 @@ REQUIRED:
         {{- $localEnabled := dig "enabled" false $localDBCtx }}
         {{- if and $localEnabled (eq (include "harnesscommon.secrets.hasESOSecrets" (dict "secretsCtx" $localDBCtx.secrets)) "true") }}
             {{- $localDBESOSecretCtxIdentifier := include "harnesscommon.dbv3.esoSecretCtxIdentifier" (dict "ctx" $ "dbType" $dbType "scope" "local" "instanceName" $instanceName) }}
-            {{- include "harnesscommon.secrets.generateExternalSecret" (dict "secretsCtx" $localDBCtx.secrets "secretNamePrefix" $localDBESOSecretCtxIdentifier) }}
+            {{- include "harnesscommon.secrets.generateExternalSecret" (dict "ctx" $ "secretsCtx" $localDBCtx.secrets "secretNamePrefix" $localDBESOSecretCtxIdentifier) }}
             {{- print "\n---" }}
         {{- end }}
     {{- end }}
@@ -511,7 +511,7 @@ REQUIRED:
         {{- $localEnabled := dig "enabled" false $localDBCtx }}
         {{- if and $localEnabled (eq (include "harnesscommon.secrets.hasESOSecrets" (dict "secretsCtx" $localDBCtx.secrets)) "true") }}
             {{- $localDBESOSecretCtxIdentifier := include "harnesscommon.dbv3.esoSecretCtxIdentifier" (dict "ctx" $ "dbType" $dbType "scope" "local" "instanceName" $instanceName) }}
-            {{- include "harnesscommon.secrets.generateExternalSecret" (dict "secretsCtx" $localDBCtx.secrets "secretNamePrefix" $localDBESOSecretCtxIdentifier) }}
+            {{- include "harnesscommon.secrets.generateExternalSecret" (dict "ctx" $ "secretsCtx" $localDBCtx.secrets "secretNamePrefix" $localDBESOSecretCtxIdentifier) }}
             {{- print "\n---" }}
         {{- end }}
     {{- end }}

--- a/src/common/templates/_eso-secrets-helper.tpl
+++ b/src/common/templates/_eso-secrets-helper.tpl
@@ -190,6 +190,12 @@ USAGE:
 {{/*
 Generates ESO External Secret CRD
 
+Automatically selects the appropriate API version:
+- Uses external-secrets.io/v1 if available (ESO 0.16.2+)
+- Falls back to external-secrets.io/v1beta1 if v1 is not available (pre-0.17.0)
+
+Note: v1beta1 support was removed in ESO v0.17.0
+
 USAGE:
 {{ include "harnesscommon.secrets.generateExternalSecret" (dict "ctx" . "secretsCtx" .Values.secrets "secretIdentifier" "local") }}
 */}}
@@ -204,7 +210,16 @@ USAGE:
             {{- if gt $esoSecretIdx 0 }}
 {{ printf "\n---"  }}
             {{- end }}
+            {{- /* Detect which API version to use based on CRD availability */ -}}
+            {{- $useV1API := false }}
+            {{- if $.Capabilities.APIVersions.Has "external-secrets.io/v1/ExternalSecret" }}
+              {{- $useV1API = true }}
+            {{- end }}
+{{- if $useV1API }}
+apiVersion: external-secrets.io/v1
+{{- else }}
 apiVersion: external-secrets.io/v1beta1
+{{- end }}
 kind: ExternalSecret
 metadata:
   name: {{ $esoSecretName }}


### PR DESCRIPTION
External Secrets has deprecated v1beta API.  We need the capability to support older versions of ES but also migrate to V1 for future releases.