### PR TITLE
Add global image registry & custom auth path in secrets-loader

### DIFF
--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.3
+version: 1.5.4
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/templates/_secret-loader.tpl
+++ b/src/common/templates/_secret-loader.tpl
@@ -36,8 +36,16 @@ Usage: {{ include "harnesscommon.secretsLoader.initContainer" (dict "ctx" .) }}
 {{- if $localSecrets }}
 {{- $mergedSecrets = mergeOverwrite $mergedSecrets $localSecrets -}}
 {{- end -}}
+{{- $imageRegistry := dig "image" "registry" "" $mergedSecrets -}}
+{{- if and (not $imageRegistry) $ctx.Values.global.imageRegistry -}}
+  {{- $imageRegistry = $ctx.Values.global.imageRegistry -}}
+{{- end -}}
 - name: secrets-loader
+{{- if $imageRegistry }}
+  image: {{ printf "%s/%s:%s" $imageRegistry $mergedSecrets.image.repository $mergedSecrets.image.tag }}
+{{- else }}
   image: {{ printf "%s:%s" $mergedSecrets.image.repository $mergedSecrets.image.tag }}
+{{- end }}
   imagePullPolicy: {{ $mergedSecrets.image.pullPolicy }}
   command: ["/opt/harness/secrets-manager"]
   args: ["load"]
@@ -199,6 +207,7 @@ Usage:   {{- include "harnesscommon.secretsloader.configContent" (dict "ctx" $ "
         {{- end }}
         {{- if eq (dig "vault" "auth" "method" "" $mergedSecrets) "kubernetes" }}
         role: {{ dig "vault" "auth" "role" "" $mergedSecrets | quote }}
+        path: {{ dig "vault" "auth" "path" "" $mergedSecrets | quote }}
         {{- end }}
     serviceName: {{ $serviceName | quote }}
     secrets:


### PR DESCRIPTION
- Added support for `global.imageRegistry` in secrets-loader init-container and `global.externalSecretsLoader.image.registry` get prioritized over `global.imageRegistry`.
- Added `auth.path` new field in secrets-loader config to support custom path for vault authentication.