### PR TITLE
chore: [CLI-54049]: Changed renderIngress 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.2] - 2026-05-14
+
+### Added
+- Moved GatewayAPI rendering to be initiated from renderIngress helper if enabled
+
 ## [1.5.2] - 2026-04-02
 
 ### Added

--- a/ci/test-chart/Chart.lock
+++ b/ci/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: file://../../src/common
-  version: 1.6.1
-digest: sha256:abd81517861f38863732ba6aad2160a5b370816d8e2939c25f17308dfb9bcea6
-generated: "2026-05-13T17:37:34.960645-06:00"
+  version: 1.6.2
+digest: sha256:506c6c2051e001ccd5ed3cf0e9ae55382bd4bfde10b7eeba1fc5762f0f469f9d
+generated: "2026-05-14T12:15:44.474601-06:00"

--- a/ci/test-chart/Chart.lock
+++ b/ci/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: file://../../src/common
-  version: 1.6.0
-digest: sha256:a09b13519d51fddb72aaa66f9009cd34e019effb7c3204eba4ec5cce01d2ccef
-generated: "2026-04-29T15:52:51.468374-06:00"
+  version: 1.6.1
+digest: sha256:abd81517861f38863732ba6aad2160a5b370816d8e2939c25f17308dfb9bcea6
+generated: "2026-05-13T17:37:34.960645-06:00"

--- a/ci/test-chart/templates/gateway-httproute.yaml
+++ b/ci/test-chart/templates/gateway-httproute.yaml
@@ -1,1 +1,0 @@
-{{- include "harnesscommon.v2.renderHTTPRoute" (dict "ctx" .) }}

--- a/ci/test-chart/templates/gateway-policies.yaml
+++ b/ci/test-chart/templates/gateway-policies.yaml
@@ -1,3 +1,0 @@
-{{- include "harnesscommon.v2.renderBackendTrafficPolicy" (dict "ctx" .) }}
-{{- include "harnesscommon.v2.renderClientTrafficPolicy" (dict "ctx" .) }}
-{{- include "harnesscommon.v2.renderSecurityPolicy" (dict "ctx" .) }}

--- a/ci/test-chart/tests/gateway_backendtrafficpolicy_test.yaml
+++ b/ci/test-chart/tests/gateway_backendtrafficpolicy_test.yaml
@@ -3,14 +3,12 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-policies.yaml
 templates:
-  - gateway-policies.yaml
-  - gateway-httproute.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
   - it: should render one shared BackendTrafficPolicy
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: BackendTrafficPolicy
@@ -19,7 +17,6 @@ tests:
           of: BackendTrafficPolicy
 
   - it: BackendTrafficPolicy should target both HTTPRoutes
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: BackendTrafficPolicy
@@ -41,7 +38,6 @@ tests:
           value: worker-routes
 
   - it: BackendTrafficPolicy should have correct timeout configuration
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: BackendTrafficPolicy
@@ -57,7 +53,6 @@ tests:
           value: 30s
 
   - it: BackendTrafficPolicy should have correct connection settings
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: BackendTrafficPolicy
@@ -70,7 +65,6 @@ tests:
           value: GRPC
 
   - it: BackendTrafficPolicy should have correct load balancer and retry settings
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: BackendTrafficPolicy

--- a/ci/test-chart/tests/gateway_clienttrafficpolicy_test.yaml
+++ b/ci/test-chart/tests/gateway_clienttrafficpolicy_test.yaml
@@ -3,13 +3,12 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-policies.yaml
 templates:
-  - gateway-policies.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
   - it: should render one ClientTrafficPolicy
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: ClientTrafficPolicy
@@ -18,7 +17,6 @@ tests:
           of: ClientTrafficPolicy
 
   - it: ClientTrafficPolicy should target the Gateway
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: ClientTrafficPolicy
@@ -40,7 +38,6 @@ tests:
           value: gateway-system
 
   - it: ClientTrafficPolicy should have correct connection settings
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: ClientTrafficPolicy
@@ -53,7 +50,6 @@ tests:
           value: 300s
 
   - it: ClientTrafficPolicy should have correct timeout settings
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: ClientTrafficPolicy
@@ -63,7 +59,6 @@ tests:
           value: 60s
 
   - it: ClientTrafficPolicy should have correct HTTP/2 settings
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: ClientTrafficPolicy

--- a/ci/test-chart/tests/gateway_headers_test.yaml
+++ b/ci/test-chart/tests/gateway_headers_test.yaml
@@ -3,18 +3,15 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-headers.yaml
 templates:
-  - gateway-httproute.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
-  - it: should render two HTTPRoutes
-    asserts:
-      - hasDocuments:
-          count: 2
-
   - it: first HTTPRoute should have RequestHeaderModifier with set headers
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
       - isKind:
           of: HTTPRoute
@@ -33,14 +30,22 @@ tests:
             value: /api
 
   - it: first HTTPRoute should have RequestHeaderModifier with add and remove headers
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - isNotNull:
           path: spec.rules[0].filters[0].requestHeaderModifier.set
 
   - it: first HTTPRoute should have ResponseHeaderModifier
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - equal:
           path: spec.rules[0].filters[1].type
           value: ResponseHeaderModifier
@@ -56,8 +61,12 @@ tests:
             value: nosniff
 
   - it: first HTTPRoute should have additional hostnames
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - contains:
           path: spec.hostnames
           content: api.example.com
@@ -72,7 +81,9 @@ tests:
           content: "*.api-staging.example.com"
 
   - it: second HTTPRoute should have global headers only
-    documentIndex: 1
+    documentSelector:
+      path: metadata.name
+      value: worker-routes
     asserts:
       - isKind:
           of: HTTPRoute

--- a/ci/test-chart/tests/gateway_headers_test.yaml
+++ b/ci/test-chart/tests/gateway_headers_test.yaml
@@ -10,8 +10,8 @@ release:
 tests:
   - it: first HTTPRoute should have RequestHeaderModifier with set headers
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /api/.*
     asserts:
       - isKind:
           of: HTTPRoute
@@ -31,8 +31,8 @@ tests:
 
   - it: first HTTPRoute should have RequestHeaderModifier with add and remove headers
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /api/.*
     asserts:
       - isKind:
           of: HTTPRoute
@@ -41,8 +41,8 @@ tests:
 
   - it: first HTTPRoute should have ResponseHeaderModifier
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /api/.*
     asserts:
       - isKind:
           of: HTTPRoute
@@ -62,8 +62,8 @@ tests:
 
   - it: first HTTPRoute should have additional hostnames
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /api/.*
     asserts:
       - isKind:
           of: HTTPRoute
@@ -82,8 +82,8 @@ tests:
 
   - it: second HTTPRoute should have global headers only
     documentSelector:
-      path: metadata.name
-      value: worker-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /worker/.*
     asserts:
       - isKind:
           of: HTTPRoute

--- a/ci/test-chart/tests/gateway_httproute_test.yaml
+++ b/ci/test-chart/tests/gateway_httproute_test.yaml
@@ -10,8 +10,8 @@ release:
 tests:
   - it: first HTTPRoute should have correct metadata and spec
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].backendRefs[0].name
+      value: test-service
     asserts:
       - isKind:
           of: HTTPRoute
@@ -27,11 +27,9 @@ tests:
 
   - it: first HTTPRoute should reference correct parent Gateway
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].backendRefs[0].name
+      value: test-service
     asserts:
-      - isKind:
-          of: HTTPRoute
       - equal:
           path: spec.parentRefs[0].name
           value: test-gateway
@@ -47,11 +45,9 @@ tests:
 
   - it: first HTTPRoute should have correct hostnames
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].backendRefs[0].name
+      value: test-service
     asserts:
-      - isKind:
-          of: HTTPRoute
       - contains:
           path: spec.hostnames
           content: api.example.com
@@ -61,11 +57,9 @@ tests:
 
   - it: first HTTPRoute should have correct backend reference
     documentSelector:
-      path: metadata.name
-      value: api-routes
+      path: spec.rules[0].backendRefs[0].name
+      value: test-service
     asserts:
-      - isKind:
-          of: HTTPRoute
       - equal:
           path: spec.rules[0].matches[0].path.type
           value: RegularExpression
@@ -81,11 +75,14 @@ tests:
 
   - it: second HTTPRoute should have correct name and backend
     documentSelector:
-      path: metadata.name
-      value: worker-routes
+      path: spec.rules[0].backendRefs[0].name
+      value: worker-service
     asserts:
       - isKind:
           of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: worker-routes
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: worker-service

--- a/ci/test-chart/tests/gateway_httproute_test.yaml
+++ b/ci/test-chart/tests/gateway_httproute_test.yaml
@@ -3,18 +3,15 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-basic.yaml
 templates:
-  - gateway-httproute.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
-  - it: should render two HTTPRoutes when gatewayAPI and ingress enabled
-    asserts:
-      - hasDocuments:
-          count: 2
-
   - it: first HTTPRoute should have correct metadata and spec
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
       - isKind:
           of: HTTPRoute
@@ -29,8 +26,12 @@ tests:
           value: default
 
   - it: first HTTPRoute should reference correct parent Gateway
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - equal:
           path: spec.parentRefs[0].name
           value: test-gateway
@@ -45,8 +46,12 @@ tests:
           value: 443
 
   - it: first HTTPRoute should have correct hostnames
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - contains:
           path: spec.hostnames
           content: api.example.com
@@ -55,8 +60,12 @@ tests:
           content: api-staging.example.com
 
   - it: first HTTPRoute should have correct backend reference
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: api-routes
     asserts:
+      - isKind:
+          of: HTTPRoute
       - equal:
           path: spec.rules[0].matches[0].path.type
           value: RegularExpression
@@ -71,13 +80,12 @@ tests:
           value: 8080
 
   - it: second HTTPRoute should have correct name and backend
-    documentIndex: 1
+    documentSelector:
+      path: metadata.name
+      value: worker-routes
     asserts:
       - isKind:
           of: HTTPRoute
-      - equal:
-          path: metadata.name
-          value: worker-routes
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: worker-service

--- a/ci/test-chart/tests/gateway_override_test.yaml
+++ b/ci/test-chart/tests/gateway_override_test.yaml
@@ -3,25 +3,12 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-per-route-override.yaml
 templates:
-  - gateway-policies.yaml
-  - gateway-httproute.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
-  - it: should render one shared policy and three per-route override policies
-    template: gateway-policies.yaml
-    asserts:
-      # 1 shared BackendTrafficPolicy (api-routes, admin-routes)
-      # 2 per-route BackendTrafficPolicy overrides (report-routes, grpc-routes)
-      # 1 shared SecurityPolicy (api-routes, report-routes, grpc-routes)
-      # 1 per-route SecurityPolicy override (admin-routes)
-      # Total: 5 documents (3 BackendTrafficPolicy, 2 SecurityPolicy)
-      - hasDocuments:
-          count: 5
-
   - it: shared BackendTrafficPolicy should target only api-routes
-    template: gateway-policies.yaml
     documentSelector:
       path: metadata.name
       value: harness-common-test-backend-policy
@@ -37,7 +24,6 @@ tests:
           value: 30s
 
   - it: report-routes should have per-route BackendTrafficPolicy override
-    template: gateway-policies.yaml
     documentSelector:
       path: metadata.name
       value: report-routes-backend-policy
@@ -56,7 +42,6 @@ tests:
           value: 1800s
 
   - it: admin-routes should have per-route SecurityPolicy override
-    template: gateway-policies.yaml
     documentSelector:
       path: metadata.name
       value: admin-routes-security-policy
@@ -78,7 +63,6 @@ tests:
           content: "10.0.0.0/8"
 
   - it: grpc-routes should have per-route BackendTrafficPolicy with gRPC settings
-    template: gateway-policies.yaml
     documentSelector:
       path: metadata.name
       value: grpc-routes-backend-policy
@@ -100,14 +84,12 @@ tests:
           value: GRPC
 
   - it: grpc-routes HTTPRoute should have custom header
-    template: gateway-httproute.yaml
     documentSelector:
       path: metadata.name
       value: grpc-routes
     asserts:
-      - equal:
-          path: metadata.name
-          value: grpc-routes
+      - isKind:
+          of: HTTPRoute
       - equal:
           path: spec.rules[0].filters[0].type
           value: RequestHeaderModifier

--- a/ci/test-chart/tests/gateway_override_test.yaml
+++ b/ci/test-chart/tests/gateway_override_test.yaml
@@ -85,8 +85,8 @@ tests:
 
   - it: grpc-routes HTTPRoute should have custom header
     documentSelector:
-      path: metadata.name
-      value: grpc-routes
+      path: spec.rules[0].matches[0].path.value
+      value: /grpc/.*
     asserts:
       - isKind:
           of: HTTPRoute

--- a/ci/test-chart/tests/gateway_securitypolicy_test.yaml
+++ b/ci/test-chart/tests/gateway_securitypolicy_test.yaml
@@ -3,14 +3,12 @@ values:
   - ../values.yaml
   - ../ci-values/gateway-policies.yaml
 templates:
-  - gateway-policies.yaml
-  - gateway-httproute.yaml
+  - ingress.yaml
 release:
   name: harness-common-test
   namespace: default
 tests:
   - it: should render one shared SecurityPolicy
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: SecurityPolicy
@@ -19,7 +17,6 @@ tests:
           of: SecurityPolicy
 
   - it: SecurityPolicy should target both HTTPRoutes
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: SecurityPolicy
@@ -41,7 +38,6 @@ tests:
           value: worker-routes
 
   - it: SecurityPolicy should have correct authorization configuration
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: SecurityPolicy
@@ -60,7 +56,6 @@ tests:
           content: "192.168.1.0/24"
 
   - it: SecurityPolicy should have correct CORS configuration
-    template: gateway-policies.yaml
     documentSelector:
       path: kind
       value: SecurityPolicy

--- a/docs/GATEWAYAPI.md
+++ b/docs/GATEWAYAPI.md
@@ -387,25 +387,18 @@ With custom ingress configuration:
 
 ### Namespace Defaulting
 
-The `parentRef.namespace` defaults to `global.namespace` when not explicitly set:
+The `parentRef.namespace` defaults to the Helm release namespace (`.Release.Namespace`) when not explicitly set:
 
 ```yaml
 global:
-  namespace: harness-helm-new
   gatewayAPI:
     enabled: true
     parentRef:
       name: envoy-gateway
-      # namespace: defaults to global.namespace ("harness-helm-new")
+      # namespace: defaults to .Release.Namespace
 ```
 
 ## Values Reference
-
-### global
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `namespace` | string | `""` | Default namespace; used as fallback for `gatewayAPI.parentRef.namespace` |
 
 ### global.gatewayAPI
 
@@ -413,7 +406,7 @@ global:
 |-----------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable GatewayAPI HTTPRoute generation (requires `global.ingress.enabled`) |
 | `parentRef.name` | string | `""` | Name of the parent Gateway resource |
-| `parentRef.namespace` | string | `""` | Namespace of the parent Gateway resource (defaults to `global.namespace`) |
+| `parentRef.namespace` | string | `""` | Namespace of the parent Gateway resource (defaults to `.Release.Namespace`) |
 | `parentRef.sectionName` | string | `""` | Specific listener name on the Gateway (optional) |
 | `parentRef.port` | int | - | Specific port on the Gateway (optional) |
 
@@ -666,7 +659,7 @@ To add GatewayAPI support to an existing service using nginx-ingress:
        enabled: true  # Add GatewayAPI
        parentRef:
          name: envoy-gateway
-         # namespace defaults to global.namespace
+         # namespace defaults to .Release.Namespace
    ```
 
 2. **No template changes needed** - `renderIngress` automatically generates

--- a/docs/GATEWAYAPI.md
+++ b/docs/GATEWAYAPI.md
@@ -362,36 +362,50 @@ ingress:
 
 ## Template Usage
 
-Include the templates in your Helm chart:
+The recommended approach is to use a single `renderIngress` call which automatically renders
+both traditional Ingress AND Gateway API resources (HTTPRoute + policies) when
+`global.gatewayAPI.enabled` is true:
 
 ```yaml
-# templates/gateway-policies.yaml
-{{- include "harnesscommon.v2.renderBackendTrafficPolicy" (dict "ctx" .) }}
-{{- include "harnesscommon.v2.renderClientTrafficPolicy" (dict "ctx" .) }}
-{{- include "harnesscommon.v2.renderSecurityPolicy" (dict "ctx" .) }}
-
-# templates/httproute.yaml
-{{- include "harnesscommon.v2.renderHTTPRoute" (dict "ctx" .) }}
+# templates/ingress.yaml (renders Ingress + Gateway API resources when enabled)
+{{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}
 ```
 
-Or include the HTTPRoute template directly:
+This single include handles everything:
+- Traditional `Ingress` objects (always, when `global.ingress.enabled`)
+- `HTTPRoute` resources (when `global.gatewayAPI.enabled`)
+- `BackendTrafficPolicy` (when `global.gatewayAPI.policies.backendTraffic.enabled`)
+- `ClientTrafficPolicy` (when `global.gatewayAPI.policies.clientTraffic.enabled`)
+- `SecurityPolicy` (when `global.gatewayAPI.policies.security.enabled`)
+
+With custom ingress configuration:
 
 ```yaml
-# templates/httproute.yaml
-{{- include "harnesscommon.v2.renderHTTPRoute" (dict "ctx" $) }}
+# templates/ingress.yaml
+{{- include "harnesscommon.v1.renderIngress" (dict "ingress" .Values.customIngress "ctx" $) }}
 ```
 
-Or with custom ingress configuration:
+### Namespace Defaulting
+
+The `parentRef.namespace` defaults to `global.namespace` when not explicitly set:
 
 ```yaml
-# templates/httproute.yaml
-{{- include "harnesscommon.v2.renderHTTPRoute" (dict 
-    "ingress" .Values.customIngress 
-    "ctx" $
-) }}
+global:
+  namespace: harness-helm-new
+  gatewayAPI:
+    enabled: true
+    parentRef:
+      name: envoy-gateway
+      # namespace: defaults to global.namespace ("harness-helm-new")
 ```
 
 ## Values Reference
+
+### global
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `namespace` | string | `""` | Default namespace; used as fallback for `gatewayAPI.parentRef.namespace` |
 
 ### global.gatewayAPI
 
@@ -399,7 +413,7 @@ Or with custom ingress configuration:
 |-----------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable GatewayAPI HTTPRoute generation (requires `global.ingress.enabled`) |
 | `parentRef.name` | string | `""` | Name of the parent Gateway resource |
-| `parentRef.namespace` | string | `""` | Namespace of the parent Gateway resource (optional) |
+| `parentRef.namespace` | string | `""` | Namespace of the parent Gateway resource (defaults to `global.namespace`) |
 | `parentRef.sectionName` | string | `""` | Specific listener name on the Gateway (optional) |
 | `parentRef.port` | int | - | Specific port on the Gateway (optional) |
 
@@ -645,19 +659,20 @@ To add GatewayAPI support to an existing service using nginx-ingress:
 1. **Enable GatewayAPI** in your values without disabling Ingress:
    ```yaml
    global:
+     namespace: harness-helm-new
      ingress:
        enabled: true  # Keep existing Ingress
      gatewayAPI:
        enabled: true  # Add GatewayAPI
        parentRef:
-         name: your-gateway
+         name: envoy-gateway
+         # namespace defaults to global.namespace
    ```
 
-2. **Create the HTTPRoute template** (if it doesn't exist):
-   ```yaml
-   # templates/httproute.yaml
-   {{- include "harnesscommon.v2.renderHTTPRoute" (dict "ctx" $) }}
-   ```
+2. **No template changes needed** - `renderIngress` automatically generates
+   Gateway API resources when `global.gatewayAPI.enabled` is true. Your existing
+   `templates/ingress.yaml` with `{{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}`
+   handles everything.
 
 3. **Test the generated resources**:
    ```bash
@@ -820,10 +835,10 @@ kubectl get httproute <name> -n your-namespace -o yaml
 
 ## Related Templates
 
+- `_ingress.tpl` - Unified entry point: renders Ingress + all Gateway API resources via `renderIngress`
 - `_gateway_httproute.tpl` - HTTPRoute generation with header manipulation and additional hostnames
 - `_gateway_backendtrafficpolicy.tpl` - Backend timeouts, connection settings, protocol, retries
 - `_gateway_clienttrafficpolicy.tpl` - Client-side connection limits and timeouts
 - `_gateway_securitypolicy.tpl` - IP whitelisting, CORS, JWT authentication
 - `_gateway_migration_helper.tpl` - Prints migration suggestions for nginx annotations
-- `_ingress.tpl` - Traditional Ingress template (can run alongside Gateway API)
 - `_service.tpl` - Service resource template

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.6.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/templates/_gateway_clienttrafficpolicy.tpl
+++ b/src/common/templates/_gateway_clienttrafficpolicy.tpl
@@ -29,12 +29,13 @@ metadata:
     {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- $parentRefNamespace := $parentRef.namespace | default $.Values.global.namespace }}
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: {{ include "harnesscommon.tplvalues.render" ( dict "value" $parentRef.name "context" $) }}
-      {{- if $parentRef.namespace }}
-      namespace: {{ include "harnesscommon.tplvalues.render" ( dict "value" $parentRef.namespace "context" $) }}
+      {{- if $parentRefNamespace }}
+      namespace: {{ include "harnesscommon.tplvalues.render" ( dict "value" $parentRefNamespace "context" $) }}
       {{- end }}
   {{- if or $clientPolicy.connection $clientPolicy.timeout $clientPolicy.http2 }}
   {{- if $clientPolicy.connection }}

--- a/src/common/templates/_gateway_clienttrafficpolicy.tpl
+++ b/src/common/templates/_gateway_clienttrafficpolicy.tpl
@@ -29,7 +29,7 @@ metadata:
     {{- include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- $parentRefNamespace := $parentRef.namespace | default $.Values.global.namespace }}
+  {{- $parentRefNamespace := $parentRef.namespace | default $.Release.Namespace }}
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/src/common/templates/_gateway_httproute.tpl
+++ b/src/common/templates/_gateway_httproute.tpl
@@ -65,10 +65,11 @@ metadata:
 spec:
   {{- if $.Values.global.gatewayAPI.parentRef }}
   # Default parentRef from global config
+  {{- $parentRefNamespace := $.Values.global.gatewayAPI.parentRef.namespace | default $.Values.global.namespace }}
   parentRefs:
     - name: {{ include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.gatewayAPI.parentRef.name "context" $) }}
-      {{- if $.Values.global.gatewayAPI.parentRef.namespace }}
-      namespace: {{ include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.gatewayAPI.parentRef.namespace "context" $) }}
+      {{- if $parentRefNamespace }}
+      namespace: {{ include "harnesscommon.tplvalues.render" ( dict "value" $parentRefNamespace "context" $) }}
       {{- end }}
       {{- if $.Values.global.gatewayAPI.parentRef.sectionName }}
       sectionName: {{ $.Values.global.gatewayAPI.parentRef.sectionName }}

--- a/src/common/templates/_gateway_httproute.tpl
+++ b/src/common/templates/_gateway_httproute.tpl
@@ -65,7 +65,7 @@ metadata:
 spec:
   {{- if $.Values.global.gatewayAPI.parentRef }}
   # Default parentRef from global config
-  {{- $parentRefNamespace := $.Values.global.gatewayAPI.parentRef.namespace | default $.Values.global.namespace }}
+  {{- $parentRefNamespace := $.Values.global.gatewayAPI.parentRef.namespace | default $.Release.Namespace }}
   parentRefs:
     - name: {{ include "harnesscommon.tplvalues.render" ( dict "value" $.Values.global.gatewayAPI.parentRef.name "context" $) }}
       {{- if $parentRefNamespace }}

--- a/src/common/templates/_ingress.tpl
+++ b/src/common/templates/_ingress.tpl
@@ -3,6 +3,9 @@ USAGE:
 {{- include "harnesscommon.v1.renderIngress" (dict "ctx" $) }}
 or
 {{- include "harnesscommon.v1.renderIngress" (dict "ingress" .Values.other.ingress "ctx" $) }}
+
+When global.gatewayAPI.enabled is true, this template also renders Gateway API
+resources (HTTPRoute, BackendTrafficPolicy, ClientTrafficPolicy, SecurityPolicy).
 */}}
 {{- define "harnesscommon.v1.renderIngress" }}
 {{- $ := .ctx }}
@@ -102,5 +105,12 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
+{{- if .ctx.Values.global.gatewayAPI.enabled }}
+# Gateway API resources (rendered by harnesscommon.v1.renderIngress)
+{{- include "harnesscommon.v2.renderHTTPRoute" . }}
+{{- include "harnesscommon.v2.renderBackendTrafficPolicy" . }}
+{{- include "harnesscommon.v2.renderClientTrafficPolicy" . }}
+{{- include "harnesscommon.v2.renderSecurityPolicy" . }}
 {{- end }}
 {{- end }}

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -1,7 +1,5 @@
 global:
   ha: false
-  # Namespace used as default for gatewayAPI.parentRef.namespace when not explicitly set
-  namespace: ""
   gatewayAPI:
     # Enable GatewayAPI HTTPRoute generation (requires global.ingress.enabled)
     enabled: false

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -1,5 +1,7 @@
 global:
   ha: false
+  # Namespace used as default for gatewayAPI.parentRef.namespace when not explicitly set
+  namespace: ""
   gatewayAPI:
     # Enable GatewayAPI HTTPRoute generation (requires global.ingress.enabled)
     enabled: false


### PR DESCRIPTION
to render gateway api objects if enabled instead of requiring users to call them individually. This allows for any future charts to be backwards compatible with new gateway api objects and in theory not require any new builds of charts that use this library to enable them with less effort. 