### PR TITLE
feat: add global service secrets injection for Resource Hierarchy Ser…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.8.0] - 2026-06-22
+
+### Added
+- **Resource Hierarchy Service secrets**: Added global service secrets injection for Resource Hierarchy Service via `harnesscommon.services.rhsEnv` template helper. Supports both Kubernetes secrets and External Secrets Operator (ESO) configuration under `global.services.resourceHierarchy`.
+
 ## [1.7.2] - 2026-05-18
 
 ### Fixed

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.2
+version: 1.8.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/templates/_services.tpl
+++ b/src/common/templates/_services.tpl
@@ -1,0 +1,37 @@
+{{/*
+Generate K8S Env Spec for Resource Hierarchy Service Secret
+
+USAGE:
+{{- include "harnesscommon.services.rhsEnv" (dict "ctx" $ "variableName" "RESOURCE_HIERARCHY_SERVICE_SECRET") | indent 12 }}
+
+PARAMETERS:
+REQUIRED:
+1. ctx - Helm context ($)
+
+OPTIONAL:
+1. variableName - Override the environment variable name (default: "RESOURCE_HIERARCHY_SERVICE_SECRET")
+
+EXAMPLE:
+env:
+  {{- include "harnesscommon.services.rhsEnv" (dict "ctx" $) | indent 12 }}
+*/}}
+{{- define "harnesscommon.services.rhsEnv" }}
+    {{- $ := .ctx }}
+    {{- $variableName := default "RESOURCE_HIERARCHY_SERVICE_SECRET" .variableName }}
+    {{- $globalServicesCtx := $.Values.global.services }}
+    {{- $rhsCtx := $globalServicesCtx.resourceHierarchy }}
+
+    {{- if and $globalServicesCtx $rhsCtx }}
+        {{- $enabled := dig "enabled" true $rhsCtx }}
+        {{- if $enabled }}
+            {{- $globalESOSecretIdentifier := include "harnesscommon.secrets.globalESOSecretCtxIdentifier" (dict "ctx" $ "ctxIdentifier" "resource-hierarchy-service") }}
+            {{- include "harnesscommon.secrets.manageEnv" (dict
+                "ctx" $
+                "variableName" "RESOURCE_HIERARCHY_SERVICE_SECRET"
+                "overrideEnvName" $variableName
+                "extKubernetesSecretCtxs" (list $rhsCtx.secrets.kubernetesSecrets)
+                "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalESOSecretIdentifier "secretCtx" $rhsCtx.secrets.secretManagement.externalSecretsOperator))
+            ) }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/src/common/values.yaml
+++ b/src/common/values.yaml
@@ -219,6 +219,26 @@ global:
       userKey: "user"
       passwordKey: "password"
       extraArgs: ""
+  # Service-to-service secrets configuration
+  # Automatically injects secrets for inter-service communication
+  services:
+    # Resource Hierarchy Service secrets
+    resourceHierarchy:
+      enabled: true
+      secrets:
+        kubernetesSecrets:
+          - secretName: ""
+            keys:
+              RESOURCE_HIERARCHY_SERVICE_SECRET: ""
+        secretManagement:
+          externalSecretsOperator:
+            - secretStore:
+                name: ""
+                kind: ""
+              remoteKeys:
+                RESOURCE_HIERARCHY_SERVICE_SECRET:
+                  name: ""
+                  property: ""
   smtpCreateSecret:
     enabled: false
     SMTP_USERNAME: ""


### PR DESCRIPTION
…vice

- Add global.services.resourceHierarchy config to values.yaml
- Create harnesscommon.services.rhsEnv helper function in _services.tpl
- Enables automatic RESOURCE_HIERARCHY_SERVICE_SECRET injection
- Pattern mirrors existing database credential injection (dbv3)
- Eliminates need for 200+ per-service secret overrides