### PR TITLE
Hotfix/fixing edge cases for charts with missing service ports/empty ingress objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Changelog
 
-## [1.8.2] - 2026-07-08
-
-### Fixed
-- **HTTPRoute `backendRef.port` used the nginx targetPort instead of the Service port**: Gateway API routes through the Service (envoy → Service ClusterIP), so `backendRef.port` must equal the Service's `spec.ports[].port`, not the nginx `backend.service.port` (which is the pod/targetPort nginx connects to directly via endpoints). The mismatch caused `ResolvedRefs=False: "TCP Port <n> not found on Service"` and 500s on affected routes (prod6: `/ng/*`, `/platform_ui/*`, registry, harness-intelligence). HTTPRoute `backendRef.port` now defaults to the chart `service.port` and accepts a per-object/per-path `gatewayAPI.backend.service.port` override; the nginx Ingress path is unchanged.
-- **HTTPRoute referenced an HTTPRouteFilter that was never emitted**: the per-rule `extensionRef.name` and the `HTTPRouteFilter.metadata.name` were computed in separate blocks and could diverge, producing a dangling reference (`ResolvedRefs=False: "Unable to translate HTTPRouteFilter"` → 500s). Both names now derive from a single shared helper (`harnesscommon.v2.httpRouteFilterName`), so the reference and its target can never differ.
-
 ## [1.8.1] - 2026-07-08
 
 ### Fixed
 - **Gateway routes/policies crash when consuming chart has no top-level `ingress:` key**: `dig "<routes>" list $ingress` panicked with `interface conversion: interface {} is nil, not map[string]interface {}` because `dig` casts its target to a map before reading keys, and the target (`$ingress`) was nil. All gateway route and policy templates now use `{{- $ingress := $.Values.ingress | default dict }}` (grpc/tcp/tls/udp routes, backendTLS/security/backendTraffic policies). This is distinct from the earlier missing-intermediate-key nil-safety fix — here the `dig` target itself was nil.
 - **Duplicate `HTTPRouteFilter` when two ingress paths slug to the same name**: paths that reduced to an identical slug + hash produced two `HTTPRouteFilter` resources with the same id, failing the post-renderer (`may not add resource with an already registered id`). The HTTPRoute template now dedupes emitted filter names per object.
+- **HTTPRoute `backendRef.port` used the nginx targetPort instead of the Service port**: Gateway API routes through the Service (envoy → Service ClusterIP), so `backendRef.port` must equal the Service's `spec.ports[].port`, not the nginx `backend.service.port` (which is the pod/targetPort nginx connects to directly via endpoints). The mismatch caused `ResolvedRefs=False: "TCP Port <n> not found on Service"` and 500s on affected routes (prod6: `/ng/*`, `/platform_ui/*`, registry, harness-intelligence). HTTPRoute `backendRef.port` now defaults to the chart `service.port` and accepts a per-object/per-path `gatewayAPI.backend.service.port` override; the nginx Ingress path is unchanged.
+- **HTTPRoute referenced an HTTPRouteFilter that was never emitted**: the per-rule `extensionRef.name` and the `HTTPRouteFilter.metadata.name` were computed in separate blocks and could diverge, producing a dangling reference (`ResolvedRefs=False: "Unable to translate HTTPRouteFilter"` → 500s). Both names now derive from a single shared helper (`harnesscommon.v2.httpRouteFilterName`), so the reference and its target can never differ.
 
 ## [1.8.0] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.1] - 2026-07-08
+
+### Fixed
+- **Gateway routes/policies crash when consuming chart has no top-level `ingress:` key**: `dig "<routes>" list $ingress` panicked with `interface conversion: interface {} is nil, not map[string]interface {}` because `dig` casts its target to a map before reading keys, and the target (`$ingress`) was nil. All gateway route and policy templates now use `{{- $ingress := $.Values.ingress | default dict }}` (grpc/tcp/tls/udp routes, backendTLS/security/backendTraffic policies). This is distinct from the earlier missing-intermediate-key nil-safety fix — here the `dig` target itself was nil.
+- **Duplicate `HTTPRouteFilter` when two ingress paths slug to the same name**: paths that reduced to an identical slug + hash produced two `HTTPRouteFilter` resources with the same id, failing the post-renderer (`may not add resource with an already registered id`). The HTTPRoute template now dedupes emitted filter names per object.
+
 ## [1.8.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.2] - 2026-07-08
+
+### Fixed
+- **HTTPRoute `backendRef.port` used the nginx targetPort instead of the Service port**: Gateway API routes through the Service (envoy → Service ClusterIP), so `backendRef.port` must equal the Service's `spec.ports[].port`, not the nginx `backend.service.port` (which is the pod/targetPort nginx connects to directly via endpoints). The mismatch caused `ResolvedRefs=False: "TCP Port <n> not found on Service"` and 500s on affected routes (prod6: `/ng/*`, `/platform_ui/*`, registry, harness-intelligence). HTTPRoute `backendRef.port` now defaults to the chart `service.port` and accepts a per-object/per-path `gatewayAPI.backend.service.port` override; the nginx Ingress path is unchanged.
+- **HTTPRoute referenced an HTTPRouteFilter that was never emitted**: the per-rule `extensionRef.name` and the `HTTPRouteFilter.metadata.name` were computed in separate blocks and could diverge, producing a dangling reference (`ResolvedRefs=False: "Unable to translate HTTPRouteFilter"` → 500s). Both names now derive from a single shared helper (`harnesscommon.v2.httpRouteFilterName`), so the reference and its target can never differ.
+
 ## [1.8.1] - 2026-07-08
 
 ### Fixed

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -33,6 +33,7 @@ run_scenario "Gateway API (migration)" "${VALUES_DIR}/gateway-migration.yaml"
 run_scenario "Gateway API (per-route overrides)" "${VALUES_DIR}/gateway-per-route-override.yaml"
 run_scenario "Gateway API (nil ingress)" "${VALUES_DIR}/gateway-nil-ingress.yaml"
 run_scenario "Gateway API (duplicate filter)" "${VALUES_DIR}/gateway-duplicate-filter.yaml"
+run_scenario "Gateway API (rewrite filter)" "${VALUES_DIR}/gateway-rewrite-filter.yaml"
 echo "All template scenarios passed."
 
 echo ""

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -31,6 +31,8 @@ run_scenario "Gateway API (policies)" "${VALUES_DIR}/gateway-policies.yaml"
 run_scenario "Gateway API (headers)" "${VALUES_DIR}/gateway-headers.yaml"
 run_scenario "Gateway API (migration)" "${VALUES_DIR}/gateway-migration.yaml"
 run_scenario "Gateway API (per-route overrides)" "${VALUES_DIR}/gateway-per-route-override.yaml"
+run_scenario "Gateway API (nil ingress)" "${VALUES_DIR}/gateway-nil-ingress.yaml"
+run_scenario "Gateway API (duplicate filter)" "${VALUES_DIR}/gateway-duplicate-filter.yaml"
 echo "All template scenarios passed."
 
 echo ""

--- a/ci/test-chart/Chart.lock
+++ b/ci/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: file://../../src/common
-  version: 1.7.2
-digest: sha256:0ed6cadfefa49ca3a981733b86861bd32d129c9d8111838dfba28ebb6f48a930
-generated: "2026-05-18T10:51:34.093756-06:00"
+  version: 1.8.1
+digest: sha256:89dc9f243c922edca78a670defa3d355f8cbd4cf9ade1f03a45f308bd649ff5c
+generated: "2026-07-08T11:25:31.371722-06:00"

--- a/ci/test-chart/Chart.lock
+++ b/ci/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: file://../../src/common
-  version: 1.8.2
-digest: sha256:4f1420b66e9b09bb4c1bbabd54790a3d5fc3bab5e2b1dacdba37f830ec7d0094
-generated: "2026-07-08T12:05:50.881019-06:00"
+  version: 1.8.1
+digest: sha256:89dc9f243c922edca78a670defa3d355f8cbd4cf9ade1f03a45f308bd649ff5c
+generated: "2026-07-09T08:35:43.017711-06:00"

--- a/ci/test-chart/Chart.lock
+++ b/ci/test-chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: harness-common
   repository: file://../../src/common
-  version: 1.8.1
-digest: sha256:89dc9f243c922edca78a670defa3d355f8cbd4cf9ade1f03a45f308bd649ff5c
-generated: "2026-07-08T11:25:31.371722-06:00"
+  version: 1.8.2
+digest: sha256:4f1420b66e9b09bb4c1bbabd54790a3d5fc3bab5e2b1dacdba37f830ec7d0094
+generated: "2026-07-08T12:05:50.881019-06:00"

--- a/ci/test-chart/ci-values/gateway-basic.yaml
+++ b/ci/test-chart/ci-values/gateway-basic.yaml
@@ -16,21 +16,32 @@ global:
 
 ingress:
   objects:
+    # api-routes: no gatewayAPI backend port override, so the HTTPRoute
+    # backendRef.port falls back to the chart's Service port (service.port: 8080).
+    # The nginx backend.service.port (4000, the pod/targetPort) is intentionally
+    # NOT used for Gateway API -- envoy routes through the Service.
     - name: api-routes
       paths:
         - path: /api(/|$)(.*)
           backend:
             service:
               name: test-service
-              port: 8080
+              port: 4000
 
+    # worker-routes: fronts a service whose Service port differs from the chart
+    # default, so it sets a per-object gatewayAPI backend port override (9090).
+    # The nginx targetPort (4001) again must not leak into backendRef.port.
     - name: worker-routes
+      gatewayAPI:
+        backend:
+          service:
+            port: 9090
       paths:
         - path: /worker/.*
           backend:
             service:
               name: worker-service
-              port: 9090
+              port: 4001
 
 service:
   port: 8080

--- a/ci/test-chart/ci-values/gateway-duplicate-filter.yaml
+++ b/ci/test-chart/ci-values/gateway-duplicate-filter.yaml
@@ -1,0 +1,30 @@
+# Edge case: two paths in the same ingress object with a rewrite-target
+# annotation that slug + hash to an identical HTTPRouteFilter name.
+# Previously this emitted two HTTPRouteFilter resources with the same
+# metadata.name, which the post-renderer rejected with
+#   may not add resource with an already registered id: HTTPRouteFilter...
+# The HTTPRoute template now dedupes filter names per object, so only one
+# HTTPRouteFilter is rendered.
+global:
+  ingress:
+    enabled: true
+    hosts:
+      - sd.example.com
+    className: harness
+  gatewayAPI:
+    enabled: true
+    parentRef:
+      name: test-gateway
+
+ingress:
+  objects:
+    - name: servicediscovery
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      paths:
+        # Two identical paths -> identical slug + hash -> same filter name.
+        - path: /api/servicediscovery(/|$)(.*)
+        - path: /api/servicediscovery(/|$)(.*)
+
+service:
+  port: 8080

--- a/ci/test-chart/ci-values/gateway-nil-ingress.yaml
+++ b/ci/test-chart/ci-values/gateway-nil-ingress.yaml
@@ -1,0 +1,25 @@
+# Edge case: gatewayAPI + ingress enabled globally, but the consuming chart
+# defines NO top-level `ingress:` key at all (so $.Values.ingress is nil).
+# Previously the gateway route/policy templates crashed with
+#   error calling dig: interface conversion: interface {} is nil, not map[string]interface {}
+# because `dig` casts its (nil) target to a map before reading keys.
+# The templates now guard with `$.Values.ingress | default dict`.
+global:
+  ingress:
+    enabled: true
+    hosts:
+      - api.example.com
+  gatewayAPI:
+    enabled: true
+    parentRef:
+      name: test-gateway
+      namespace: gateway-system
+
+# Explicitly null the top-level `ingress` key to reproduce a consuming chart
+# (e.g. le-nextgen) that never defines one. `null` overrides the test chart's
+# own `ingress: {objects: []}` default in values.yaml, forcing $.Values.ingress
+# to be nil — the exact condition that triggered the dig panic in prod.
+ingress: null
+
+service:
+  port: 8080

--- a/ci/test-chart/ci-values/gateway-rewrite-filter.yaml
+++ b/ci/test-chart/ci-values/gateway-rewrite-filter.yaml
@@ -1,0 +1,28 @@
+# Gateway API HTTPRoute with rewrite-target -> each rule emits an ExtensionRef
+# pointing at an HTTPRouteFilter. Regression coverage for the "dangling
+# extensionRef" bug: every extensionRef.name MUST have a matching emitted
+# HTTPRouteFilter (both derive their name from the shared
+# harnesscommon.v2.httpRouteFilterName helper, so they cannot diverge).
+global:
+  ingress:
+    enabled: true
+    hosts:
+      - ui.example.com
+    className: harness
+  gatewayAPI:
+    enabled: true
+    parentRef:
+      name: test-gateway
+
+ingress:
+  objects:
+    - name: next-gen-ui
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+      paths:
+        # Two DISTINCT paths -> two distinct filter names, each referenced and emitted.
+        - path: /ng(/|$)(.*)
+        - path: /platform_ui(/|$)(.*)
+
+service:
+  port: 8080

--- a/ci/test-chart/tests/gateway_duplicate_filter_test.yaml
+++ b/ci/test-chart/tests/gateway_duplicate_filter_test.yaml
@@ -1,0 +1,28 @@
+suite: Gateway API duplicate HTTPRouteFilter edge case (harnesscommon.v2.renderHTTPRoute)
+# Regression: two paths in the same ingress object with a rewrite-target
+# annotation that slug + hash to the same name used to emit two HTTPRouteFilter
+# resources with an identical metadata.name, failing the post-renderer with
+# "may not add resource with an already registered id". The template now dedupes
+# filter names per object, so exactly one HTTPRouteFilter is rendered.
+values:
+  - ../values.yaml
+  - ../ci-values/gateway-duplicate-filter.yaml
+templates:
+  - ingress.yaml
+release:
+  name: harness-common-test
+  namespace: default
+tests:
+  # documentSelector without matchMany requires EXACTLY ONE matching document,
+  # so this test fails if the dedup regresses and a second HTTPRouteFilter with
+  # the same name reappears.
+  - it: should render exactly one HTTPRouteFilter for duplicate paths
+    documentSelector:
+      path: kind
+      value: HTTPRouteFilter
+    asserts:
+      - isKind:
+          of: HTTPRouteFilter
+      - equal:
+          path: metadata.name
+          value: servicediscovery-api-servicediscovery-3f9838

--- a/ci/test-chart/tests/gateway_httproute_test.yaml
+++ b/ci/test-chart/tests/gateway_httproute_test.yaml
@@ -55,7 +55,11 @@ tests:
           path: spec.hostnames
           content: api-staging.example.com
 
-  - it: first HTTPRoute should have correct backend reference
+  - it: first HTTPRoute backendRef.port uses the Service port, not the nginx targetPort
+    # Bug 1 regression: Gateway API routes through the Service, so backendRef.port
+    # must equal the Service spec.ports[].port (service.port: 8080 here) -- NOT the
+    # nginx backend.service.port (4000, the pod/targetPort). A targetPort here yields
+    # ResolvedRefs=False "TCP Port not found on Service" and 500s the route.
     documentSelector:
       path: spec.rules[0].backendRefs[0].name
       value: test-service
@@ -73,7 +77,10 @@ tests:
           path: spec.rules[0].backendRefs[0].port
           value: 8080
 
-  - it: second HTTPRoute should have correct name and backend
+  - it: second HTTPRoute backendRef.port uses the per-object gatewayAPI port override
+    # worker-routes sets gatewayAPI.backend.service.port: 9090 to front a Service
+    # whose port differs from the chart default; the nginx targetPort (4001) must
+    # not leak into backendRef.port.
     documentSelector:
       path: spec.rules[0].backendRefs[0].name
       value: worker-service

--- a/ci/test-chart/tests/gateway_nil_ingress_test.yaml
+++ b/ci/test-chart/tests/gateway_nil_ingress_test.yaml
@@ -1,0 +1,21 @@
+suite: Gateway API nil ingress edge case (harnesscommon.v1.renderIngress)
+# Regression: when a consuming chart enables gatewayAPI + ingress globally but
+# defines no top-level `ingress:` key ($.Values.ingress is nil), the gateway
+# route/policy templates used to crash on `dig "<routes>" list $ingress` with
+# "interface conversion: interface {} is nil". `ingress: null` in the ci-value
+# overrides the test chart's own default to reproduce that condition exactly.
+values:
+  - ../values.yaml
+  - ../ci-values/gateway-nil-ingress.yaml
+templates:
+  - ingress.yaml
+release:
+  name: harness-common-test
+  namespace: default
+tests:
+  - it: should render without error when top-level ingress is nil
+    asserts:
+      # The template renders successfully (no dig panic). With no routes
+      # defined, no gateway route/policy documents are produced.
+      - hasDocuments:
+          count: 0

--- a/ci/test-chart/tests/gateway_rewrite_filter_test.yaml
+++ b/ci/test-chart/tests/gateway_rewrite_filter_test.yaml
@@ -1,0 +1,53 @@
+suite: Gateway API HTTPRouteFilter reference integrity (harnesscommon.v2.renderHTTPRoute)
+# Regression: the per-rule extensionRef and the HTTPRouteFilter it points at are
+# emitted from separate blocks. If their names diverge, the route references a
+# filter that is never emitted -> ResolvedRefs=False "Unable to translate
+# HTTPRouteFilter" -> 500s. Both names now come from the shared
+# harnesscommon.v2.httpRouteFilterName helper, so they must match. These tests
+# assert the concrete referenced name equals the concrete emitted filter name
+# for each distinct rewrite path.
+values:
+  - ../values.yaml
+  - ../ci-values/gateway-rewrite-filter.yaml
+templates:
+  - ingress.yaml
+release:
+  name: harness-common-test
+  namespace: default
+tests:
+  - it: HTTPRoute rule 0 extensionRef points at the /ng filter name
+    documentSelector:
+      path: kind
+      value: HTTPRoute
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: ExtensionRef
+      - equal:
+          path: spec.rules[0].filters[0].extensionRef.kind
+          value: HTTPRouteFilter
+      - equal:
+          path: spec.rules[0].filters[0].extensionRef.name
+          value: next-gen-ui-ng-ad548b
+      - equal:
+          path: spec.rules[1].filters[0].extensionRef.name
+          value: next-gen-ui-platformui-85b36d
+
+  - it: emits an HTTPRouteFilter for the /ng path matching the extensionRef name
+    documentSelector:
+      path: metadata.name
+      value: next-gen-ui-ng-ad548b
+    asserts:
+      - isKind:
+          of: HTTPRouteFilter
+      - equal:
+          path: apiVersion
+          value: gateway.envoyproxy.io/v1alpha1
+
+  - it: emits an HTTPRouteFilter for the /platform_ui path matching the extensionRef name
+    documentSelector:
+      path: metadata.name
+      value: next-gen-ui-platformui-85b36d
+    asserts:
+      - isKind:
+          of: HTTPRouteFilter

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/Chart.yaml
+++ b/src/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.2
+version: 1.8.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/src/common/templates/_gateway_backendtlspolicy.tpl
+++ b/src/common/templates/_gateway_backendtlspolicy.tpl
@@ -21,7 +21,7 @@ ingress:
 */}}
 {{- define "harnesscommon.v2.renderBackendTLSPolicy" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_backendtrafficpolicy.tpl
+++ b/src/common/templates/_gateway_backendtrafficpolicy.tpl
@@ -11,7 +11,7 @@ Supports hybrid approach (Option C):
 */}}
 {{- define "harnesscommon.v2.renderBackendTrafficPolicy" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_grpcroute.tpl
+++ b/src/common/templates/_gateway_grpcroute.tpl
@@ -28,7 +28,7 @@ ingress:
 */}}
 {{- define "harnesscommon.v2.renderGRPCRoute" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_httproute.tpl
+++ b/src/common/templates/_gateway_httproute.tpl
@@ -266,6 +266,10 @@ spec:
       {{- end }}
     {{- end }}
 {{- if and $objectAnnotations (hasKey $objectAnnotations "nginx.ingress.kubernetes.io/rewrite-target") }}
+{{- /* Track filter names already emitted for this object so that duplicate paths
+(which slug + hash to an identical name) don't produce two HTTPRouteFilter resources
+with the same id, which would fail rendering. */}}
+{{- $seenFilterNames := dict }}
 {{- range $idx := $chunkPaths }}
 {{- $renderedPath := include "harnesscommon.tplvalues.render" ( dict "value" $idx.path "context" $) }}
 {{- $step1 := $renderedPath | trimPrefix "/" }}
@@ -283,11 +287,14 @@ spec:
     {{- $pathSlug = $pathSlugFull }}
   {{- end }}
 {{- end }}
+{{- $filterName := ternary (cat $chunkRouteName "-" $pathSlug "-" $shortHash | nospace) (cat $chunkRouteName "-" $shortHash | nospace) (ne $pathSlug "") }}
+{{- if not (hasKey $seenFilterNames $filterName) }}
+{{- $_ := set $seenFilterNames $filterName true }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter
 metadata:
-  name: {{ if $pathSlug }}{{ cat $chunkRouteName "-" $pathSlug "-" $shortHash | nospace }}{{ else }}{{ cat $chunkRouteName "-" $shortHash | nospace }}{{ end }}
+  name: {{ $filterName }}
   namespace: {{ $.Release.Namespace }}
   {{- if $.Values.global.commonLabels }}
   labels:
@@ -321,6 +328,7 @@ spec:
       replaceRegexMatch:
         pattern: {{ include "harnesscommon.tplvalues.render" ( dict "value" $idx.path "context" $) }}
         substitution: {{ include "harnesscommon.tplvalues.render" ( dict "value" ( regexReplaceAll "\\$" (get $objectAnnotations "nginx.ingress.kubernetes.io/rewrite-target") "\\" ) "context" $) }}
+{{- end }} {{/* If filter name not already emitted */}}
 {{- end }} {{/* Range over chunk paths */}}
 {{- end }} {{/* If to create HTTPRouteFilter */}}
 {{- end }} {{/* Range over chunks */}}

--- a/src/common/templates/_gateway_httproute.tpl
+++ b/src/common/templates/_gateway_httproute.tpl
@@ -4,6 +4,43 @@ USAGE:
 or
 {{- include "harnesscommon.v2.renderHTTPRoute" (dict "gateway" .Values.other.gateway "ctx" $) }}
 */}}
+
+{{/*
+Compute the deterministic name of the HTTPRouteFilter (Envoy Gateway urlRewrite)
+for a given route + rendered path. This MUST be the single source of truth: the
+per-rule `extensionRef.name` (the reference) and the `HTTPRouteFilter.metadata.name`
+(the target) are emitted from separate blocks, so both call this helper to guarantee
+the reference can never point at a name that isn't emitted.
+
+USAGE:
+{{ include "harnesscommon.v2.httpRouteFilterName" (dict "routeName" $chunkRouteName "path" $renderedPath) }}
+where $renderedPath is the already-rendered path string.
+*/}}
+{{- define "harnesscommon.v2.httpRouteFilterName" -}}
+{{- $routeName := .routeName -}}
+{{- $renderedPath := .path -}}
+{{- $step1 := $renderedPath | trimPrefix "/" -}}
+{{- $step2 := regexReplaceAll "[^a-zA-Z0-9/]" $step1 "" -}}
+{{- $step3 := regexReplaceAll "/" $step2 "-" -}}
+{{- $step4 := regexReplaceAll "-+" $step3 "-" -}}
+{{- $pathSlugFull := $step4 | trimSuffix "-" | lower -}}
+{{- $shortHash := sha1sum $renderedPath | trunc 6 -}}
+{{- $maxPathLen := sub 253 (add (len $routeName) 8) | int -}}
+{{- $pathSlug := "" -}}
+{{- if $pathSlugFull -}}
+  {{- if gt (len $pathSlugFull) $maxPathLen -}}
+    {{- $pathSlug = trunc $maxPathLen $pathSlugFull | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $pathSlug = $pathSlugFull -}}
+  {{- end -}}
+{{- end -}}
+{{- if $pathSlug -}}
+{{- cat $routeName "-" $pathSlug "-" $shortHash | nospace -}}
+{{- else -}}
+{{- cat $routeName "-" $shortHash | nospace -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "harnesscommon.v2.renderHTTPRoute" }}
 {{- $ := .ctx }}
 {{- $ingress := $.Values.ingress }}
@@ -115,7 +152,14 @@ spec:
   rules:
     {{- range $idx := $chunkPaths }}
     {{- $serviceName := dig "backend" "service" "name" $.Chart.Name $idx }}
-    {{- $servicePort := dig "backend" "service" "port" $.Values.service.port $idx }}
+    {{- /* Gateway API routes through the Service (envoy -> Service ClusterIP), so
+    backendRef.port MUST be the Service's spec.ports[].port -- NOT the nginx
+    backend.service.port, which is the pod/targetPort that nginx connects to
+    directly via endpoints. Using the targetPort here yields
+    ResolvedRefs=False "TCP Port <n> not found on Service" and 500s the route.
+    Precedence: per-path gatewayAPI.backend.service.port > per-object
+    gatewayAPI.backend.service.port > chart service.port (the Service's declared port). */}}
+    {{- $servicePort := dig "gatewayAPI" "backend" "service" "port" (dig "gatewayAPI" "backend" "service" "port" $.Values.service.port $object) $idx }}
     {{- $globalHttpRoute := dig "httpRoute" dict $.Values.global.gatewayAPI }}
     {{- $perRouteHttpRoute := dig "gatewayAPI" dict $object }}
     {{- $hasRewriteTarget := and $objectAnnotations (hasKey $objectAnnotations "nginx.ingress.kubernetes.io/rewrite-target") }}
@@ -228,29 +272,16 @@ spec:
               {{- end }}
             {{- end }}
         {{- end }}
-        {{- /* URL Rewrite filter (existing logic) */}}
+        {{- /* URL Rewrite filter. The extensionRef name is computed by the shared
+        helper so it always matches the emitted HTTPRouteFilter below (same predicate,
+        same computed name) -- never a dangling reference. */}}
         {{- if $hasRewriteTarget }}
         {{- $renderedPath := include "harnesscommon.tplvalues.render" ( dict "value" $idx.path "context" $) }}
-        {{- $step1 := $renderedPath | trimPrefix "/" }}
-        {{- $step2 := regexReplaceAll "[^a-zA-Z0-9/]" $step1 "" }}
-        {{- $step3 := regexReplaceAll "/" $step2 "-" }}
-        {{- $step4 := regexReplaceAll "-+" $step3 "-" }}
-        {{- $pathSlugFull := $step4 | trimSuffix "-" | lower }}
-        {{- $shortHash := sha1sum $renderedPath | trunc 6 }}
-        {{- $maxPathLen := sub 253 (add (len $chunkRouteName) 8) | int }}
-        {{- $pathSlug := "" }}
-        {{- if $pathSlugFull }}
-          {{- if gt (len $pathSlugFull) $maxPathLen }}
-            {{- $pathSlug = trunc $maxPathLen $pathSlugFull | trimSuffix "-" }}
-          {{- else }}
-            {{- $pathSlug = $pathSlugFull }}
-          {{- end }}
-        {{- end }}
         - type: ExtensionRef
           extensionRef:
             group: gateway.envoyproxy.io
             kind: HTTPRouteFilter
-            name: {{ if $pathSlug }}{{ cat $chunkRouteName "-" $pathSlug "-" $shortHash | nospace }}{{ else }}{{ cat $chunkRouteName "-" $shortHash | nospace }}{{ end }}
+            name: {{ include "harnesscommon.v2.httpRouteFilterName" (dict "routeName" $chunkRouteName "path" $renderedPath) }}
         {{- end }}
       {{- end }}
       # Backend services
@@ -272,22 +303,7 @@ with the same id, which would fail rendering. */}}
 {{- $seenFilterNames := dict }}
 {{- range $idx := $chunkPaths }}
 {{- $renderedPath := include "harnesscommon.tplvalues.render" ( dict "value" $idx.path "context" $) }}
-{{- $step1 := $renderedPath | trimPrefix "/" }}
-{{- $step2 := regexReplaceAll "[^a-zA-Z0-9/]" $step1 "" }}
-{{- $step3 := regexReplaceAll "/" $step2 "-" }}
-{{- $step4 := regexReplaceAll "-+" $step3 "-" }}
-{{- $pathSlugFull := $step4 | trimSuffix "-" | lower }}
-{{- $shortHash := sha1sum $renderedPath | trunc 6 }}
-{{- $maxPathLen := sub 253 (add (len $chunkRouteName) 8) | int }}
-{{- $pathSlug := "" }}
-{{- if $pathSlugFull }}
-  {{- if gt (len $pathSlugFull) $maxPathLen }}
-    {{- $pathSlug = trunc $maxPathLen $pathSlugFull | trimSuffix "-" }}
-  {{- else }}
-    {{- $pathSlug = $pathSlugFull }}
-  {{- end }}
-{{- end }}
-{{- $filterName := ternary (cat $chunkRouteName "-" $pathSlug "-" $shortHash | nospace) (cat $chunkRouteName "-" $shortHash | nospace) (ne $pathSlug "") }}
+{{- $filterName := include "harnesscommon.v2.httpRouteFilterName" (dict "routeName" $chunkRouteName "path" $renderedPath) }}
 {{- if not (hasKey $seenFilterNames $filterName) }}
 {{- $_ := set $seenFilterNames $filterName true }}
 ---

--- a/src/common/templates/_gateway_securitypolicy.tpl
+++ b/src/common/templates/_gateway_securitypolicy.tpl
@@ -11,7 +11,7 @@ Supports hybrid approach (Option C):
 */}}
 {{- define "harnesscommon.v2.renderSecurityPolicy" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_tcproute.tpl
+++ b/src/common/templates/_gateway_tcproute.tpl
@@ -19,7 +19,7 @@ ingress:
 */}}
 {{- define "harnesscommon.v2.renderTCPRoute" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_tlsroute.tpl
+++ b/src/common/templates/_gateway_tlsroute.tpl
@@ -19,7 +19,7 @@ ingress:
 */}}
 {{- define "harnesscommon.v2.renderTLSRoute" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}

--- a/src/common/templates/_gateway_udproute.tpl
+++ b/src/common/templates/_gateway_udproute.tpl
@@ -18,7 +18,7 @@ ingress:
 */}}
 {{- define "harnesscommon.v2.renderUDPRoute" }}
 {{- $ := .ctx }}
-{{- $ingress := $.Values.ingress }}
+{{- $ingress := $.Values.ingress | default dict }}
 {{- if .ingress -}}
     {{- $ingress = .ingress }}
 {{- end }}


### PR DESCRIPTION
  What was fixed: Two Gateway API HTTPRoute bugs that caused production 500s — (1) backendRef.port emitted the pod targetPort instead of the Service port, and (2) HTTPRoutes referenced an HTTPRouteFilter that was never
  emitted (name divergence between the reference and the resource).

  How it was tested:
  - Back-filled ~78 real production chart builds with 1.8.2 — the actual packaged charts pulled from the cluster/registry, spanning harness-common versions 1.3.84 → 1.8.0 — and rendered each with its full pipeline chain.
  - Checked two invariants on every render: every backendRef.port matches a real Service spec.ports[].port, and every extensionRef has a matching emitted HTTPRouteFilter.
  - Schema-validated every manifest with kubeconform against the Gateway API + Envoy CRD schemas.
  - Cross-referenced against a live scan of all 102 releases to confirm coverage of the 68 ingress-bearing charts.
  - Used prod4 release secrets (deployed manifests + merged values) as ground truth to resolve the few charts that couldn't be pulled from the registry.
  - Added regression tests to the chart's CI suite, each proven to fail against the pre-fix templates and pass after (73→76 tests, all green).

  Result: 1.8.2 introduces zero regressions across every chart verified. It fixes the filter bug fleet-wide and the port bug for every correctly-configured chart. Four charts remain broken by pre-existing chart-side defects 