### PR TITLE
fix: sort merged secret keys alphabetically for deterministic env var order

### DIFF
--- a/src/common/templates/_eso-secrets-helper.tpl
+++ b/src/common/templates/_eso-secrets-helper.tpl
@@ -283,7 +283,7 @@ USAGE:
 {{- end}}
 {{- $defaultSecretName := dig "defaultSecretName" $.Chart.Name $.Values.secrets }}
 {{- $conditionsList := .ctx.Values.secrets }}
-{{- $mergedSecretKeys := keys $defaultSecretList $kubernetesSecretsList $ESOSecretsList | uniq }}
+{{- $mergedSecretKeys := keys $defaultSecretList $kubernetesSecretsList $ESOSecretsList | uniq | sortAlpha }}
 {{- range $key := $mergedSecretKeys }}
     {{- if not (has $key $fileSecretMap) }}
     {{- $diggedCondition := dig "conditions" $key "NOTFOUND" $conditionsList }}


### PR DESCRIPTION
harnesscommon.renderSecretsAsEnvironmentVariables merged keys from three Sprig maps via `keys`, whose iteration order is randomized per render. This produced a different env var order on every helm template/upgrade even with unchanged values, causing spurious manifest diffs. Sorting the merged keys alphabetically makes the output deterministic.